### PR TITLE
refactor: Restructure documentation to eliminate duplication and impr…

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,719 @@
+# CardShark API Documentation
+
+This document provides a comprehensive reference for CardShark's FastAPI backend endpoints.
+
+## Base URL
+
+**Development**: `http://localhost:9696`
+**Production**: Depends on deployment configuration
+
+## Table of Contents
+
+- [World Cards API](#world-cards-api)
+- [Characters API](#characters-api)
+- [Chat API](#chat-api)
+- [Settings API](#settings-api)
+- [Templates API](#templates-api)
+- [Content Filters API](#content-filters-api)
+- [Background API](#background-api)
+- [Rooms API](#rooms-api)
+
+---
+
+## World Cards API
+
+Base path: `/api/world-cards/`
+
+Manages World Cards - dynamic, navigable environments with characters and events.
+
+### List Worlds
+
+```http
+GET /api/world-cards/
+```
+
+**Response**: Array of available world names
+
+**Example:**
+```json
+["fantasy-kingdom", "cyberpunk-city", "space-station"]
+```
+
+---
+
+### Get World State
+
+```http
+GET /api/world-cards/{world_name}/state
+```
+
+**Parameters:**
+- `world_name` (path) - Name of the world
+
+**Response**: World state object including rooms, NPCs, player position, etc.
+
+**Example Response:**
+```json
+{
+  "world_name": "fantasy-kingdom",
+  "current_room": "throne-room",
+  "rooms": {
+    "throne-room": {
+      "name": "Throne Room",
+      "description": "A grand hall with marble columns",
+      "npcs": ["king", "guard"],
+      "events": []
+    }
+  },
+  "player_position": "throne-room"
+}
+```
+
+---
+
+### Update World State
+
+```http
+POST /api/world-cards/{world_name}/state
+```
+
+**Parameters:**
+- `world_name` (path) - Name of the world
+
+**Request Body**: Updated world state object
+
+**Response**: Success confirmation
+
+---
+
+### Move Player
+
+```http
+POST /api/world-cards/{world_name}/move
+```
+
+**Parameters:**
+- `world_name` (path) - Name of the world
+
+**Request Body:**
+```json
+{
+  "destination": "garden",
+  "player_id": "player-uuid"
+}
+```
+
+**Response**: Updated player position and room information
+
+---
+
+### Create World
+
+```http
+POST /api/world-cards/create
+```
+
+**Request Body:**
+```json
+{
+  "world_name": "new-world",
+  "description": "A mysterious new world",
+  "initial_room": "entrance"
+}
+```
+
+**Response**: Created world state
+
+---
+
+## Characters API
+
+Base path: `/api/characters/`
+
+Manages character data with PNG metadata embedding.
+
+### List Characters
+
+```http
+GET /api/characters/
+```
+
+**Response**: Array of character objects
+
+**Example:**
+```json
+[
+  {
+    "character_uuid": "550e8400-e29b-41d4-a716-446655440000",
+    "name": "Elena",
+    "description": "A brave warrior",
+    "file_path": "characters/elena.png"
+  }
+]
+```
+
+---
+
+### Save Character Card
+
+```http
+POST /api/characters/save-card
+```
+
+**Request**: Multipart form data with PNG file and metadata
+
+**Form Fields:**
+- `file` - PNG image file
+- `metadata` - JSON string with character data (including `character_uuid`)
+
+**Response**: Saved character with embedded metadata
+
+**Metadata Example:**
+```json
+{
+  "character_uuid": "550e8400-e29b-41d4-a716-446655440000",
+  "name": "Elena",
+  "description": "A brave warrior from the northern kingdoms",
+  "personality": "Courageous, loyal, quick-witted",
+  "first_message": "Greetings, traveler!"
+}
+```
+
+---
+
+### Extract Character Metadata
+
+```http
+POST /api/characters/extract-metadata
+```
+
+**Request**: Multipart form data with PNG file
+
+**Response**: Extracted metadata from PNG EXIF data
+
+---
+
+### Get Character by ID
+
+```http
+GET /api/characters/{character_id}
+```
+
+**Parameters:**
+- `character_id` (path) - Character UUID or name
+
+**Response**: Character object with full metadata
+
+---
+
+## Chat API
+
+Base path: `/api/chat/`
+
+Manages chat sessions and message generation.
+
+### Generate Chat Response
+
+```http
+POST /api/chat/generate
+```
+
+**Request Body:**
+```json
+{
+  "chat_session_uuid": "abc123-session-uuid",
+  "character_id": "elena",
+  "message": "Hello!",
+  "api_config": {
+    "provider": "openai",
+    "model": "gpt-4",
+    "temperature": 0.8
+  }
+}
+```
+
+**Response**: Server-sent events (SSE) stream with AI-generated response
+
+**SSE Event Format:**
+```
+data: {"token": "Hello", "done": false}
+data: {"token": " there", "done": false}
+data: {"token": "!", "done": true}
+```
+
+---
+
+### List Chat Sessions
+
+```http
+GET /api/chat/list/{character_id}
+```
+
+**Parameters:**
+- `character_id` (path) - Character UUID or name
+
+**Response**: Array of chat sessions for the character
+
+**Example:**
+```json
+[
+  {
+    "chat_session_uuid": "session-123",
+    "character_id": "elena",
+    "created_at": "2025-12-26T10:00:00Z",
+    "last_message_at": "2025-12-26T11:30:00Z",
+    "message_count": 42
+  }
+]
+```
+
+---
+
+### Load Chat Session
+
+```http
+POST /api/chat/load
+```
+
+**Request Body:**
+```json
+{
+  "chat_session_uuid": "session-123"
+}
+```
+
+**Response**: Complete chat history with messages
+
+**Example:**
+```json
+{
+  "chat_session_uuid": "session-123",
+  "character_id": "elena",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hello!",
+      "timestamp": "2025-12-26T10:00:00Z"
+    },
+    {
+      "role": "assistant",
+      "content": "Greetings, traveler!",
+      "timestamp": "2025-12-26T10:00:05Z"
+    }
+  ],
+  "session_notes": "Elena is on a quest to find the ancient sword",
+  "compression_enabled": true
+}
+```
+
+---
+
+### Create New Chat Session
+
+```http
+POST /api/chat/create-new-chat
+```
+
+**Request Body:**
+```json
+{
+  "character_id": "elena",
+  "session_notes": "Starting a new adventure"
+}
+```
+
+**Response**: New chat session UUID
+
+---
+
+### Append Chat Message
+
+```http
+POST /api/chat/append-chat-message
+```
+
+**Request Body:**
+```json
+{
+  "chat_session_uuid": "session-123",
+  "role": "user",
+  "content": "What should we do next?"
+}
+```
+
+**Response**: Success confirmation
+
+---
+
+### Load Latest Chat
+
+```http
+GET /api/chat/load-latest-chat/{character_id}
+```
+
+**Parameters:**
+- `character_id` (path) - Character UUID or name
+
+**Response**: Most recent chat session for the character
+
+---
+
+## Settings API
+
+Base path: `/api/settings/`
+
+Manages application configuration.
+
+### Get Settings
+
+```http
+GET /api/settings/
+```
+
+**Response**: Current application settings
+
+**Example:**
+```json
+{
+  "api": {
+    "default_provider": "openai",
+    "openai_api_key": "sk-...",
+    "default_model": "gpt-4"
+  },
+  "ui": {
+    "theme": "dark",
+    "font_size": "medium"
+  },
+  "paths": {
+    "characters_dir": "characters/",
+    "worlds_dir": "worlds/",
+    "chats_dir": "chats/"
+  }
+}
+```
+
+---
+
+### Update Settings
+
+```http
+POST /api/settings/
+```
+
+**Request Body**: Settings object (partial updates supported)
+
+**Example:**
+```json
+{
+  "api": {
+    "default_provider": "anthropic",
+    "anthropic_api_key": "sk-ant-..."
+  }
+}
+```
+
+**Response**: Updated settings
+
+---
+
+## Templates API
+
+Base path: `/api/templates/`
+
+Manages chat prompt templates.
+
+### List Templates
+
+```http
+GET /api/templates/
+```
+
+**Response**: Array of available templates
+
+**Example:**
+```json
+[
+  {
+    "name": "default",
+    "description": "Standard chat template",
+    "file_path": "templates/default.json"
+  },
+  {
+    "name": "roleplay",
+    "description": "Immersive roleplay template",
+    "file_path": "templates/roleplay.json"
+  }
+]
+```
+
+---
+
+### Get Template
+
+```http
+GET /api/templates/{template_name}
+```
+
+**Parameters:**
+- `template_name` (path) - Name of the template
+
+**Response**: Template content
+
+**Example:**
+```json
+{
+  "name": "default",
+  "system_prompt": "You are a helpful assistant",
+  "user_prefix": "User: ",
+  "assistant_prefix": "Assistant: ",
+  "format": "{{system_prompt}}\n\n{{history}}\n\n{{user_prefix}}{{message}}\n{{assistant_prefix}}"
+}
+```
+
+---
+
+### Create/Update Template
+
+```http
+POST /api/templates/
+```
+
+**Request Body**: Template object
+
+**Response**: Saved template confirmation
+
+---
+
+### Delete Template
+
+```http
+DELETE /api/templates/{template_name}
+```
+
+**Parameters:**
+- `template_name` (path) - Name of the template to delete
+
+**Response**: Success confirmation
+
+---
+
+## Content Filters API
+
+Base path: `/api/content-filters/`
+
+Manages content moderation filters.
+
+### List Filters
+
+```http
+GET /api/content-filters/
+```
+
+**Response**: Array of available content filters (builtin and custom)
+
+---
+
+### Get Filter
+
+```http
+GET /api/content-filters/{filter_name}
+```
+
+**Parameters:**
+- `filter_name` (path) - Name of the filter
+
+**Response**: Filter configuration and rules
+
+---
+
+### Create/Update Custom Filter
+
+```http
+POST /api/content-filters/
+```
+
+**Request Body**: Filter configuration
+
+**Response**: Saved filter confirmation
+
+---
+
+### Delete Custom Filter
+
+```http
+DELETE /api/content-filters/{filter_name}
+```
+
+**Parameters:**
+- `filter_name` (path) - Name of custom filter to delete (builtin filters cannot be deleted)
+
+**Response**: Success confirmation
+
+---
+
+## Background API
+
+Base path: `/api/backgrounds/`
+
+Manages background images for chat customization.
+
+### List Backgrounds
+
+```http
+GET /api/backgrounds/
+```
+
+**Response**: Array of available backgrounds with metadata
+
+---
+
+### Upload Background
+
+```http
+POST /api/backgrounds/upload
+```
+
+**Request**: Multipart form data with image file and metadata
+
+**Response**: Uploaded background information
+
+---
+
+### Delete Background
+
+```http
+DELETE /api/backgrounds/{background_name}
+```
+
+**Parameters:**
+- `background_name` (path) - Name of background to delete
+
+**Response**: Success confirmation
+
+---
+
+## Rooms API
+
+Base path: `/api/rooms/`
+
+Manages chat rooms and conversation spaces.
+
+### List Rooms
+
+```http
+GET /api/rooms/
+```
+
+**Response**: Array of available rooms
+
+---
+
+### Create Room
+
+```http
+POST /api/rooms/
+```
+
+**Request Body**: Room configuration
+
+**Response**: Created room object
+
+---
+
+### Update Room
+
+```http
+PUT /api/rooms/{room_id}
+```
+
+**Parameters:**
+- `room_id` (path) - Room identifier
+
+**Request Body**: Updated room configuration
+
+**Response**: Updated room object
+
+---
+
+### Delete Room
+
+```http
+DELETE /api/rooms/{room_id}
+```
+
+**Parameters:**
+- `room_id` (path) - Room identifier
+
+**Response**: Success confirmation
+
+---
+
+## Error Responses
+
+All endpoints follow consistent error response formats:
+
+### Standard Error Response
+
+```json
+{
+  "error": "Error type",
+  "message": "Detailed error message",
+  "status_code": 400
+}
+```
+
+### Common HTTP Status Codes
+
+- `200 OK` - Request successful
+- `201 Created` - Resource created successfully
+- `400 Bad Request` - Invalid request data
+- `404 Not Found` - Resource not found
+- `422 Unprocessable Entity` - Validation error
+- `500 Internal Server Error` - Server error
+
+### Example Error Response
+
+```json
+{
+  "error": "ValidationError",
+  "message": "character_uuid is required in metadata",
+  "status_code": 422,
+  "details": {
+    "field": "character_uuid",
+    "constraint": "required"
+  }
+}
+```
+
+---
+
+## Request/Response Conventions
+
+### Content Types
+
+- **JSON requests**: `Content-Type: application/json`
+- **File uploads**: `Content-Type: multipart/form-data`
+- **SSE responses**: `Content-Type: text/event-stream`
+
+### Authentication
+
+Currently, CardShark is designed for local use and does not require authentication. API keys for AI providers are stored in settings and used server-side.
+
+### CORS
+
+CORS is configured to allow requests from the frontend during development:
+- Development frontend: `http://localhost:6969`
+- Production: Served from the same origin as the backend
+
+---
+
+## Additional Resources
+
+- **[Development Guide](DEVELOPMENT.md)** - Setup and testing
+- **[Code Conventions](../.kiro/steering/conventions.md)** - Backend patterns and standards
+- **[Project Structure](../.kiro/steering/structure.md)** - Backend file organization
+- **[Persistence Architecture](persistence_architecture.md)** - Data storage patterns
+
+---
+
+For questions or issues, join the [CardShark Discord](https://discord.gg/RfVts3hYsd).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,383 @@
+# CardShark Development Guide
+
+This guide covers setting up your development environment, running tests, and building CardShark for production.
+
+> **Note for Users**: If you're just using CardShark, download the latest `.exe` release. This guide is for developers who want to contribute to or modify CardShark.
+
+## Table of Contents
+- [Prerequisites](#prerequisites)
+- [Quick Start](#quick-start)
+- [Frontend Setup](#frontend-setup)
+- [Backend Setup](#backend-setup)
+- [Running Tests](#running-tests)
+- [Building for Production](#building-for-production)
+- [Development Workflow](#development-workflow)
+- [Coding Standards](#coding-standards)
+
+## Prerequisites
+
+Before you begin, ensure you have:
+
+1. **Node.js** (v16 or later) and **npm** - [Download here](https://nodejs.org/)
+2. **Python** (v3.9 or later) and **pip** - [Download here](https://www.python.org/)
+3. **Git** for version control
+4. (Optional) **Vite** globally: `npm install -g vite`
+5. (Optional) **Jest** globally: `npm install -g jest`
+
+## Quick Start
+
+The fastest way to get both frontend and backend running:
+
+```bash
+# From the project root
+python start.py
+```
+
+This starts:
+- **Backend** at `http://localhost:9696`
+- **Frontend** at `http://localhost:6969`
+
+Visit `http://localhost:6969` in your browser to use the application.
+
+## Frontend Setup
+
+### Installation
+
+```bash
+cd frontend
+npm install
+```
+
+### Development Server
+
+```bash
+npm run dev
+```
+
+The frontend will be available at `http://localhost:6969` (or as specified by Vite).
+
+### Frontend Project Structure
+
+See [Project Structure](../.kiro/steering/structure.md#frontend-structure-frontendrc) for detailed organization.
+
+**Key directories:**
+- `src/components/` - Reusable UI components
+- `src/views/` - Page-level components
+- `src/contexts/` - React Context providers for state management
+- `src/hooks/` - Custom React hooks
+- `src/api/` - API client modules
+- `src/types/` - TypeScript type definitions
+
+### Frontend Technologies
+
+- **Framework**: React 18 with TypeScript
+- **Build Tool**: Vite with SWC
+- **Styling**: Tailwind CSS
+- **Routing**: React Router v7
+- **Rich Text**: TipTap editor
+- **Testing**: Jest with React Testing Library
+
+See [Tech Stack](../.kiro/steering/tech.md) for complete details.
+
+## Backend Setup
+
+### Installation
+
+```bash
+cd backend
+
+# Create virtual environment
+python -m venv venv
+
+# Activate virtual environment
+# Windows:
+venv\Scripts\activate
+# macOS/Linux:
+source venv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt
+```
+
+### Development Server
+
+```bash
+# Make sure virtual environment is activated
+python main.py
+
+# Or use uvicorn directly for auto-reload:
+uvicorn main:app --reload --port 9696
+```
+
+The backend API will be available at `http://localhost:9696`.
+
+### Backend Project Structure
+
+See [Project Structure](../.kiro/steering/structure.md#backend-structure-backend) for detailed organization.
+
+**Key components:**
+- `*_endpoints.py` - FastAPI routers for different features
+- `handlers/` - Business logic classes
+- `services/` - Service layer for complex operations
+- `models/` - Pydantic data models
+- `utils/` - Utility functions
+- `database.py` - SQLAlchemy database setup
+- `sql_models.py` - Database table definitions
+
+### Backend Technologies
+
+- **Framework**: FastAPI with uvicorn
+- **Database**: SQLite with SQLAlchemy ORM
+- **Image Processing**: Pillow (PIL)
+- **Validation**: Pydantic v2
+- **Testing**: pytest with asyncio support
+
+See [Tech Stack](../.kiro/steering/tech.md) for complete details.
+
+## Running Tests
+
+### Frontend Tests
+
+```bash
+cd frontend
+
+# Run all tests
+npm test
+
+# Run with coverage
+npm run test:coverage
+
+# Run in watch mode
+npm test -- --watch
+```
+
+Frontend tests use **Jest** and **React Testing Library** with **MSW** for API mocking.
+
+### Backend Tests
+
+```bash
+cd backend
+
+# Make sure virtual environment is activated
+
+# Run all tests
+pytest
+
+# Run with coverage
+pytest --cov
+
+# Run specific test file
+pytest testing/test_specific_feature.py
+
+# Run with verbose output
+pytest -v
+```
+
+Backend tests use **pytest** with asyncio support.
+
+## Building for Production
+
+### Frontend Build
+
+```bash
+cd frontend
+npm run build
+```
+
+This creates optimized production files in `frontend/dist/`.
+
+### Full Executable Build
+
+CardShark can be packaged as a standalone Windows executable:
+
+```bash
+# From project root
+python build.py
+```
+
+This script:
+1. Builds the frontend with Vite
+2. Packages everything with PyInstaller
+3. Creates a standalone `.exe` in the `dist/` folder
+
+The executable includes both the frontend and backend, along with all dependencies.
+
+## Development Workflow
+
+### Making Changes
+
+1. **Create a feature branch**
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+2. **Make your changes following the coding standards** (see below)
+
+3. **Test your changes**
+   - Write unit tests for new features
+   - Run existing tests to ensure nothing breaks
+   - Test manually in the browser
+
+4. **Run linters and formatters**
+   ```bash
+   # Frontend
+   cd frontend
+   npm run lint
+
+   # Backend (if configured)
+   cd backend
+   black .
+   isort .
+   ```
+
+5. **Commit and push**
+   ```bash
+   git add .
+   git commit -m "feat: Add your feature description"
+   git push origin feature/your-feature-name
+   ```
+
+6. **Submit a pull request** with a clear description of your changes
+
+### Git Commit Message Conventions
+
+Use clear, descriptive commit messages:
+- `feat:` - New feature
+- `fix:` - Bug fix
+- `docs:` - Documentation changes
+- `refactor:` - Code refactoring
+- `test:` - Adding or updating tests
+- `chore:` - Maintenance tasks
+
+## Coding Standards
+
+CardShark follows strict coding standards to maintain code quality and consistency.
+
+### Python (Backend)
+
+- **Follow PEP 8** for Python code style
+- **Use type hints** for all function signatures and variables
+- **Async/await** for all database operations and API calls
+- **Pydantic models** for request/response validation
+- **Custom exceptions** from `errors.py`
+- **Logging** via `log_manager.py` for errors and important events
+
+**Example:**
+```python
+async def get_character(character_id: str) -> CharacterData:
+    """Retrieve character by ID with proper error handling."""
+    try:
+        character = await db.get_character(character_id)
+        return character
+    except NotFoundError:
+        logger.error(f"Character not found: {character_id}")
+        raise
+```
+
+### TypeScript/React (Frontend)
+
+- **Strict TypeScript** - No `any` types allowed
+- **Functional components** with hooks only
+- **Context + hooks** for state management (no external libraries)
+- **Tailwind CSS** for styling - avoid inline styles
+- **Proper error boundaries** and loading states
+- **DEBUG flag** for console.log statements (set to false for production)
+
+**Example:**
+```typescript
+interface ChatViewProps {
+  characterId: string;
+  sessionId: string;
+}
+
+const ChatView: React.FC<ChatViewProps> = ({ characterId, sessionId }) => {
+  const [messages, setMessages] = useState<Message[]>([]);
+
+  // Component logic...
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* JSX content */}
+    </div>
+  );
+};
+```
+
+### Naming Conventions
+
+**Backend:**
+- Endpoint files: `*_endpoints.py`
+- Handler classes: `*_handler.py`
+- Service/Manager classes: `*_service.py` or `*_manager.py`
+
+**Frontend:**
+- Components: PascalCase `.tsx` files (`ChatView.tsx`)
+- Hooks: `use*` prefix (`useChatMessages.ts`)
+- API clients: `*Api.ts` suffix (`worldApi.ts`)
+
+See [Code Conventions](../.kiro/steering/conventions.md) for complete details.
+
+## Project Organization
+
+### Data Directories
+
+The following directories are created at runtime and contain user data:
+
+- `characters/` - Character PNG files with embedded metadata
+- `worlds/` - World state files and location-specific chats
+- `backgrounds/` - Background images with metadata
+- `users/` - User profile PNGs
+- `templates/` - Chat prompt templates
+- `chats/` - Chat history (JSONL/JSON format)
+- `uploads/` - User-uploaded files
+- `logs/` - Runtime and build logs
+- `settings.json` - Global configuration
+
+### Configuration Files
+
+- **Frontend**: `vite.config.ts`, `tailwind.config.js`, `jest.config.ts`
+- **Backend**: `requirements.txt`, database configuration in `database.py`
+- **Build**: `build.py` (PyInstaller configuration)
+
+## Troubleshooting
+
+### Common Issues
+
+**Frontend won't start:**
+- Ensure Node.js v16+ is installed
+- Delete `node_modules/` and `package-lock.json`, then run `npm install`
+- Check that port 6969 isn't already in use
+
+**Backend won't start:**
+- Ensure Python 3.9+ is installed
+- Verify virtual environment is activated
+- Check that all dependencies installed: `pip install -r requirements.txt`
+- Ensure port 9696 isn't already in use
+
+**Tests failing:**
+- Ensure all dependencies are installed
+- Check that database migrations are up to date
+- Clear any cached test data
+
+**Build fails:**
+- Ensure frontend builds successfully first (`cd frontend && npm run build`)
+- Check that PyInstaller is installed in your Python environment
+- Review logs in `logs/` directory
+
+## Additional Resources
+
+- [Product Overview](../.kiro/steering/product.md) - Features and use cases
+- [Project Structure](../.kiro/steering/structure.md) - Detailed file organization
+- [Code Conventions](../.kiro/steering/conventions.md) - Coding patterns and best practices
+- [Tech Stack](../.kiro/steering/tech.md) - Complete technology details
+- [API Documentation](API.md) - API endpoint reference
+
+## Getting Help
+
+- **Discord**: Join the [CardShark Discord](https://discord.gg/RfVts3hYsd)
+- **Issues**: Check existing issues or create a new one on GitHub
+- **Documentation**: Review the docs linked above
+
+---
+
+Happy coding! 🦈

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,255 +1,67 @@
+# CardShark
+
 Feedback, issues, or gripes? Just want to hang out? Hit us up on the [CardShark Discord](https://discord.gg/RfVts3hYsd).
 
-CardShark is a PNG metadata editor and AI Chatbot front end built exclusively by AI assistants.
+**CardShark** is a PNG metadata editor and AI chatbot frontend built exclusively by AI assistants. It's designed for interactive storytelling and character-driven chat experiences.
 
 ![cs_gallery](https://github.com/user-attachments/assets/4ab24c52-3a9c-4c96-9c30-77ed822f677b)
-![cs_charinfo](https://github.com/user-attachments/assets/79bd551c-ab8f-42e9-a1eb-9a7fddb2eb8b)
-![cs_compare](https://github.com/user-attachments/assets/c757f693-5f27-42c3-a4a3-f54af63bb53d)
-![cs_greetings](https://github.com/user-attachments/assets/3f484ba5-2ac2-4511-a61e-3d7ff08838ec)
-![cs_lore](https://github.com/user-attachments/assets/b83ecf38-52f8-433f-8cb7-392d803385c4)
 ![cs_chat](https://github.com/user-attachments/assets/c1f9999d-89c5-420a-9f7d-bb7f9e74dac0)
-![cs_api](https://github.com/user-attachments/assets/3d091e6b-770d-4c8b-881e-b0d2a2a3b121)
-![cs_templates](https://github.com/user-attachments/assets/a54b277d-8a38-4fbc-bc1a-3f23406b1aeb)
-![cs_prompts](https://github.com/user-attachments/assets/60cd72e6-dcf5-4a2f-b821-342d8c5e030e)
 
-# CardShark Project Documentation
+## Key Features
 
-## Project Overview
-CardShark is a React-based web application with a Python backend designed for interactive storytelling and character-driven chat experiences. The project leverages modern web technologies like Tailwind CSS for styling, Vite for fast builds, and Jest for testing. It supports dynamic chat interactions, customizable settings, integration with AI models for generating responses, and a "World Cards" system for dynamic, character-driven environments.
+- **Character Management**: Create and manage AI characters with metadata embedded in PNG files
+- **Dynamic Chat System**: Real-time streaming conversations with multiple AI providers
+- **World Cards System**: Navigate dynamic maps and interact with AI-driven characters
+- **Template Management**: Customizable prompt templates for different conversation styles
+- **Persistent Identity**: UUID-based character tracking embedded in PNG metadata
+- **Comprehensive Persistence**: Robust data storage with atomic operations and error recovery
 
-### Key Features
-- **Dynamic Chat System**: Engage in interactive conversations with AI-driven characters.
-- **World Cards System**: Navigate dynamic maps, interact with AI-driven characters, and experience events that shape the world. (See `plan_WorldCards2.md` for full details).
-- **Customizable Settings**: Tailor the chat experience with background settings, API configurations, and UI preferences.
-- **Template Management**: Create, edit, and manage templates for chat formatting. (See `templates_README.md`).
-- **API Integration**: Seamless integration with AI models for generating responses.
-- **Persistent Character Identity**: Utilizes unique identifiers (UUIDs) embedded directly within character PNG metadata for stable and robust tracking. (See `backend_character_uuid_implementation_plan.md`).
-- **Comprehensive Persistence**: Robust data storage for chats, worlds, settings, etc., with atomic operations and error recovery. (See `persistence_architecture.md`).
+For complete feature details, see [Product Overview](../.kiro/steering/product.md).
 
-## Repository Structure
+## Quick Start
 
-The workspace is organized into the following key folders:
+### For Users
+1. Download the latest release (`.exe` for Windows)
+2. Run the executable
+3. Configure your AI provider in Settings
+4. Start chatting!
 
-### Backend (`backend/`)
-The backend is implemented in Python using FastAPI. It provides APIs for managing characters, worlds, settings, and more.
+### For Developers
+See **[DEVELOPMENT.md](DEVELOPMENT.md)** for complete setup instructions.
 
--   **Core Files**:
-    -   [`main.py`](backend/main.py:1): Initializes the FastAPI app and includes routers for various endpoints.
-    -   [`api_handler.py`](backend/api_handler.py:1): Handles general API interactions and request processing.
-    -   [`world_endpoints.py`](backend/world_endpoints.py:1): Implements endpoints for World Card operations (CRUD, state management, player movement).
-    -   [`character_endpoints.py`](backend/character_endpoints.py:1): Manages character-related APIs (CRUD, metadata extraction/embedding, import).
-    -   [`chat_endpoints.py`](backend/chat_endpoints.py:1): Handles chat-related API endpoints.
-    -   [`settings_endpoints.py`](backend/settings_endpoints.py:1): Handles application settings.
--   **Handlers**:
-    -   [`world_state_handler.py`](backend/handlers/world_state_handler.py:1) / [`world_state_manager.py`](backend/world_state_manager.py:1): Manages world state logic, including loading, saving, and initialization.
-    -   [`chat_handler.py`](backend/chat_handler.py:1): Handles chat-related business logic, message storage, and retrieval.
-    -   [`background_handler.py`](backend/background_handler.py:1): Manages background assets and metadata.
-    -   [`png_metadata_handler.py`](backend/png_metadata_handler.py:1): Utility for reading and writing EXIF metadata to PNG files (characters, user profiles).
-    -   [`settings_manager.py`](backend/settings_manager.py:1): Manages loading, saving, and validation of application settings from `settings.json`.
-    -   [`koboldcpp_manager.py`](backend/koboldcpp_manager.py:1): Integrates with the KoboldCPP AI model.
-    -   [`template_handler.py`](backend/template_handler.py:1): Manages chat templates.
--   **Models (`backend/models/`)**:
-    -   Contains Pydantic models for data validation and structuring (e.g., [`world_state.py`](backend/models/world_state.py:1), [`character_data.py`](backend/models/character_data.py:1)).
--   **Utilities (`backend/utils/`)**:
-    -   Includes helper functions and utilities such as [`location_extractor.py`](backend/utils/location_extractor.py:1) for World Cards, and [`user_dirs.py`](backend/utils/user_dirs.py:1) for path management.
-    -   [`errors.py`](backend/errors.py:1): Defines custom error classes.
-    -   [`log_manager.py`](backend/log_manager.py:1): Provides logging utilities.
+**Quick version:**
+```bash
+# Clone and run development servers
+python start.py
 
-### Frontend (`frontend/`)
-The frontend is built with React and TypeScript. It uses Vite for development and build processes, and Tailwind CSS for styling.
+# Backend at http://localhost:9696
+# Frontend at http://localhost:6969
+```
 
--   **Core Files**:
-    -   [`src/main.tsx`](frontend/src/main.tsx:1): Entry point for the React application.
-    -   [`src/App.tsx`](frontend/src/App.tsx:1): Main application component, sets up routing.
-    -   [`src/components/`](frontend/src/components/): Contains reusable UI components (e.g., [`ChatView.tsx`](frontend/src/components/ChatView.tsx:1), [`APISettingsView.tsx`](frontend/src/components/APISettingsView.tsx:1), `CharacterGallery.tsx`, `WorldMap.tsx`).
-    -   [`src/views/`](frontend/src/views/): Higher-level view components (e.g., [`WorldCardsView.tsx`](frontend/src/views/WorldCardsView.tsx:1)).
-    -   [`src/api/`](frontend/src/api/): API client modules for interacting with the backend (e.g., [`worldApi.ts`](frontend/src/api/worldApi.ts:1), `characterApi.ts`).
--   **State Management (`frontend/src/contexts/`)**:
-    -   Context providers for managing global and feature-specific state (e.g., [`ChatContext.tsx`](frontend/src/contexts/ChatContext.tsx:1), [`WorldStateContext.tsx`](frontend/src/contexts/WorldStateContext.tsx:1), [`APIConfigContext.tsx`](frontend/src/contexts/APIConfigContext.tsx:1), [`CharacterContext.tsx`](frontend/src/contexts/CharacterContext.tsx:1)).
--   **Hooks (`frontend/src/hooks/`)**:
-    -   Custom hooks for managing component logic and side effects (e.g., [`useChatMessages.ts`](frontend/src/hooks/useChatMessages.ts:1), [`useWorldState.ts`]).
--   **Types (`frontend/src/types/`)**:
-    -   TypeScript type definitions and interfaces (e.g., [`schema.ts`](frontend/src/types/schema.ts:1), [`world.ts`](frontend/src/types/world.ts:1)).
--   **Styling**:
-    -   [`tailwind.config.js`](frontend/tailwind.config.js): Tailwind CSS configuration.
-    -   [`src/index.css`](frontend/src/index.css:1): Global styles.
--   **Testing**:
-    -   [`jest.config.ts`](frontend/jest.config.ts:1): Jest configuration for unit and integration tests.
--   **Public Assets (`frontend/public/`)**:
-    -   Static assets like images (`cardshark.ico`, `pngPlaceholder.png`) and icons.
--   **Build Configuration**:
-    -   [`vite.config.ts`](frontend/vite.config.ts:1): Vite build and development server configuration.
+## Documentation
 
-### Shared Resources & Data Directories
--   **`worlds/`**: Stores world data, including `world_state.json` files, images, and location-specific chats.
--   **`characters/`**: Contains character PNG files with embedded metadata.
--   **`templates/`**: Stores chat templates (JSON format) and related documentation.
--   **`backgrounds/`**: Background images and `metadata.json` for chat customization.
--   **`users/`**: User profile PNGs with embedded metadata.
--   **`chats/`**: Stores chat history, typically organized by character name, using JSONL or JSON files.
--   **`uploads/`**: Default directory for user-uploaded files.
--   **`logs/`**: Build and runtime logs for debugging.
--   **`testing/`**: Contains backend test cases and utilities.
--   **`settings.json`**: Global configuration file for the project, managed by `settings_manager.py`.
+### Project Guides
+- **[Product Overview](../.kiro/steering/product.md)** - Features and use cases
+- **[Project Structure](../.kiro/steering/structure.md)** - Repository organization
+- **[Code Conventions](../.kiro/steering/conventions.md)** - Coding standards and patterns
+- **[Tech Stack](../.kiro/steering/tech.md)** - Technologies and dependencies
 
-### Miscellaneous
--   **`build/`**: Build artifacts and compiled files (typically frontend).
--   **`.gitignore`**: Specifies intentionally untracked files that Git should ignore.
--   **`LICENSE`**: Project license file (likely AGPL based on `docs/GNU_AGPL_license.md`).
+### Developer Resources
+- **[Development Guide](DEVELOPMENT.md)** - Setup, testing, and build instructions
+- **[API Documentation](API.md)** - Complete endpoint reference
+- **[Changelog](CHANGELOG.md)** - Version history and updates
 
-## Functionality and Features
+## Contributing
 
-### World Cards
-World Cards represent dynamic, navigable environments where users can interact with characters and events.
--   **Backend**: [`world_endpoints.py`](backend/world_endpoints.py:1) (APIs), [`world_state_handler.py`](backend/handlers/world_state_handler.py:1) (logic).
--   **Frontend**: [`src/views/WorldCardsView.tsx`](frontend/src/views/WorldCardsView.tsx:1) (management UI), [`src/views/WorldView.tsx`](frontend/src/views/WorldView.tsx:1) (play UI), [`src/api/worldApi.ts`](frontend/src/api/worldApi.ts:1) (client).
+1. Read the [Code Conventions](../.kiro/steering/conventions.md)
+2. Check the [Development Guide](DEVELOPMENT.md) for setup
+3. Follow the coding standards and test your changes
+4. Submit a pull request with a clear description
 
-### Characters
-Characters are central, with metadata embedded in PNGs, including a unique `character_uuid`.
--   **Backend**: [`character_endpoints.py`](backend/character_endpoints.py:1) (APIs, metadata handling).
--   **Frontend**: [`src/components/CharacterGallery.tsx`](frontend/src/components/CharacterGallery.tsx:1) (display), [`src/components/CharacterInfoView.tsx`](frontend/src/components/CharacterInfoView.tsx:1) (details), `src/api/characterApi.ts` (client).
+## License
 
-### Chat System
-Interactive conversations with AI-driven characters, using customizable templates.
--   **Backend**: [`chat_endpoints.py`](backend/chat_endpoints.py:1) (APIs), [`chat_handler.py`](backend/chat_handler.py:1) (logic).
--   **Frontend**: [`src/components/ChatView.tsx`](frontend/src/components/ChatView.tsx:1) (UI), [`src/hooks/useChatMessages.ts`](frontend/src/hooks/useChatMessages.ts:1) (state), [`frontend/src/handlers/promptHandler.ts`](frontend/src/handlers/promptHandler.ts:1) (formatting).
-
-### Settings
-Application settings are configurable, including API keys, UI preferences, and directory paths.
--   **Backend**: [`settings_endpoints.py`](backend/settings_endpoints.py:1) (APIs), [`settings_manager.py`](backend/settings_manager.py:1) (file I/O).
--   **Frontend**: [`src/components/APISettingsView.tsx`](frontend/src/components/APISettingsView.tsx:1) (UI).
-
-## Routing and Endpoints
-
-### Backend API Endpoints (FastAPI)
-Key API routes defined in `backend/main.py` and respective endpoint files:
--   `/api/world-cards/`: Manages World Cards.
-    -   `GET /{world_name}/state`: Retrieves the state of a world.
-    -   `POST /{world_name}/state`: Updates the state of a world.
-    -   `POST /{world_name}/move`: Moves a player within a world.
-    -   `POST /create`: Creates a new world.
-    -   `GET /`: Lists available worlds.
--   `/api/characters/`: Manages character data.
-    -   `POST /save-card`: Saves a character card with embedded metadata (including `character_uuid`).
-    -   `POST /extract-metadata`: Extracts metadata from character files.
-    -   `GET /`: Lists available characters.
--   `/api/chat/`: Manages chat operations.
-    -   `POST /generate`: Generates a chat response using the configured LLM.
-    -   `GET /list/{character_id}`: Lists chat sessions for a character.
-    -   `POST /load`: Loads a specific chat session.
--   `/api/settings/`: Manages application settings.
-    -   `GET /`: Retrieves current settings.
-    -   `POST /`: Updates settings.
--   `/api/templates/`: Manages chat templates.
-    -   `GET /`: Lists templates.
-    -   `POST /`: Creates/updates a template.
-
-### Frontend Routing (React Router)
-Key client-side routes defined in [`src/App.tsx`](frontend/src/App.tsx:1) or similar routing configuration:
--   `/gallery`: Displays the character gallery.
--   `/worldcards`: Manages World Cards (listing, creation).
--   `/worldcards/:worldName`: View/play a specific World Card.
--   `/chat/:characterId?/:chatId?`: Main chat interface.
--   `/settings/*`: Application settings (e.g., `/settings/api`, `/settings/templates`).
-
-## Dependencies
-
-### Frontend Dependencies (`frontend/package.json`)
--   **Core**: `react`, `react-dom`, `react-router-dom`
--   **Rich Text Editing**: `@tiptap/react`, `@tiptap/starter-kit`, various `@tiptap/extension-*`
--   **Image Manipulation**: `cropperjs`, `react-cropper`
--   **Icons**: `lucide-react`
--   **UI & Utilities**: `react-intersection-observer`, `zod` (schema validation), `uuid`
--   **Development**: `vite`, `typescript`, `@vitejs/plugin-react`, `jest`, `@testing-library/react`, `eslint`, `tailwindcss`, `postcss`, `autoprefixer`
-
-### Backend Dependencies (`backend/requirements.txt`)
--   **Core Framework**: `fastapi`, `uvicorn[standard]`
--   **File Handling & Image Processing**: `Pillow`, `python-multipart`
--   **Data Validation & Settings**: `pydantic`
--   **System Utilities**: `psutil`, `Send2Trash`
--   **HTTP & Streaming**: `requests`, `sse-starlette`
--   **Packaging**: `pyinstaller` (for creating executables)
-
-## ========================== DEV ONLY =====================================
-## Development Workflow (Not for users - Users should use the .EXE releases)
-## ========================== DEV ONLY =====================================
-
-### Prerequisites
-1.  Install **Node.js** (v16 or later) and **npm**.
-2.  Install **Python** (v3.9 or later) and **pip**.
-3.  (Optional) Install **Vite** globally: `npm install -g vite`.
-4.  (Optional) Install **Jest** globally: `npm install -g jest`.
-5.  Clone the repository and navigate to the project directory.
-
-### Setting Up the Frontend
-1.  Navigate to the `frontend/` folder: `cd frontend`.
-2.  Install dependencies: `npm install`.
-3.  Start the development server: `npm run dev`.
-4.  Access the application at `http://localhost:5173` (or as specified by Vite).
-
-### Setting Up the Backend
-1.  Navigate to the `backend/` folder: `cd backend`.
-2.  Create a virtual environment: `python -m venv venv`.
-3.  Activate the virtual environment:
-    -   On Windows: `venv\Scripts\activate`
-    -   On macOS/Linux: `source venv/bin/activate`
-4.  Install dependencies: `pip install -r requirements.txt`.
-5.  Start the backend server: `python main.py` (or `uvicorn main:app --reload` for development).
-
-### Running Tests
--   **Frontend**: In `frontend/`, run `npm test`.
--   **Backend**: In `backend/`, run `pytest`.
-
-### Building for Production
-1.  Build the frontend: In `frontend/`, run `npm run build`.
-2.  The backend can be packaged using PyInstaller if needed, or deployed as a Python application. Serve the built frontend files (typically from `frontend/dist`) via the backend or a separate web server.
-
-## Coding Standards
-
-### React (Frontend)
--   Use functional components and hooks.
--   Keep components small and focused on a single responsibility.
--   Use TypeScript for type safety; define interfaces for props and state.
--   Follow Tailwind CSS conventions for styling.
--   Write unit tests for components and hooks using Jest and React Testing Library.
-
-### Python (Backend)
--   Follow PEP 8 for Python code style.
--   Use type hints for function signatures and variables.
--   Use Pydantic models for request/response data validation and serialization.
--   Write unit tests for modules and endpoints using `pytest`.
--   Log errors and important events using `log_manager.py`.
-
-### General Best Practices
--   Write clear and concise comments for complex logic.
--   Use meaningful variable, function, and class names.
--   Avoid hardcoding values; use configuration files (`settings.json`) or environment variables.
--   Handle errors gracefully and provide user-friendly messages or appropriate HTTP status codes.
--   Optimize for performance and scalability where necessary.
--   Ensure documentation is updated alongside code changes.
-
-## Contribution Workflow
-1.  Clone the repository and set up the development environment as described above.
-2.  Create a new branch for your feature or bug fix.
-3.  Follow the coding standards and development guidelines (for AI agent specific rules, refer to [Cursor Rules](docs/cursorrules.md)).
-4.  Write or update relevant documentation for your changes.
-5.  Test your changes thoroughly (unit tests, integration tests, manual testing).
-6.  Run linters and formatters: `npm run lint` (frontend), `black .` and `isort .` (backend).
-7.  Submit a pull request with a clear description of your changes.
-
-## Additional Resources
--   **Persistence Architecture**: See [`docs/persistence_architecture.md`](docs/persistence_architecture.md).
--   **Character UUIDs**: See [`docs/backend_character_uuid_implementation_plan.md`](docs/backend_character_uuid_implementation_plan.md).
--   **Chat Storage Implementation**: See [`docs/chat_storage_transition_plan.md`](docs/chat_storage_transition_plan.md) for the complete database-only chat system.
--   **Chat Persistence Strategy**: See [`docs/chat_persistence_strategy.md`](docs/chat_persistence_strategy.md) for architectural overview.
--   **World Cards System Plan**: See [`docs/plan_WorldCards2.md`](docs/plan_WorldCards2.md).
--   **World Persistence Strategy**: See [`docs/world_persistence_strategy.md`](docs/world_persistence_strategy.md).
--   **World Prompts**: See [`docs/world_prompts.md`](docs/world_prompts.md).
--   **Templates Guide**: See [`docs/templates_README.md`](docs/templates_README.md).
--   **User Flows**: See [`docs/# CardShark User Flows.md`](docs/%23%20CardShark%20User%20Flows.md).
--   **Frontend Code Review (State)**: See [`docs/frontend_code_review_current_state.md`](docs/frontend_code_review_current_state.md).
--   **Cursor Rules**: See [`docs/cursorrules.md`](docs/cursorrules.md).
+This project is licensed under the GNU Affero General Public License v3.0 (AGPL-3.0). See [LICENSE](../LICENSE) or [GNU_AGPL_license.md](GNU_AGPL_license.md) for details.
 
 ---
-This document serves as a comprehensive guide to the CardShark repository. For further assistance, refer to the linked detailed documentation or contact project maintainers.
 
+Built with ❤️ by AI assistants for the AI character community.


### PR DESCRIPTION
…ove clarity

- Streamlined README.md from 256 to 68 lines
  - Removed duplicate content covered by steering files
  - Removed non-existent file references
  - Fixed relative paths to steering documentation
  - Focused on being a landing page that directs to appropriate docs

- Created docs/DEVELOPMENT.md
  - Comprehensive developer setup guide
  - Extracted from old README and tech.md
  - Includes prerequisites, setup, testing, and building instructions
  - Added troubleshooting section and coding standards

- Created docs/API.md
  - Complete API endpoint reference
  - Documented all backend routes with request/response examples
  - Added error response conventions
  - Organized by feature area (World Cards, Characters, Chat, etc.)

This refactor addresses the issue of README serving too many masters by separating concerns into focused, single-purpose documentation files that reference the existing steering conventions rather than duplicating them.