### PR TITLE
Convert character card to world builder

### DIFF
--- a/frontend/src/types/character.ts
+++ b/frontend/src/types/character.ts
@@ -45,6 +45,7 @@ export interface CharacterCoreData {
   tags?: string[] | null;
   creator?: string | null;
   character_version?: string | null;
+  character_uuid?: string | null; // UUID for canonical character identification
   extensions?: CharacterExtensions;
   // World Card Specific Additions
   combat_stats?: NpcCombatStats | null;

--- a/frontend/src/views/WorldLauncher.tsx
+++ b/frontend/src/views/WorldLauncher.tsx
@@ -87,6 +87,7 @@ const WorldLauncher: React.FC = () => {
                      creator_notes: charData.creator_comment,
                      tags: charData.tags,
                      extensions: extensions,
+                     character_uuid: uuid, // Include UUID so InfoViewRouter can get worldId
                      // Add other fields as needed
                   }
                };


### PR DESCRIPTION
…Builder navigation

When converting a Character to a World, the WorldLauncher loads the world card into the character context. However, it was missing the character_uuid field, which caused InfoViewRouter to be unable to get the worldId. This prevented the World Builder from loading when clicking "World Builder" in the side navigation.

Changes:
- Add character_uuid to mappedData.data in WorldLauncher
- Add character_uuid field to CharacterCoreData type definition

This fixes the issue where clicking "World Builder" in side nav shows "Basic Info & Greetings" instead of the World Editor after converting a character to a world.