### PR TITLE
fix: Resolve TypeScript build errors in frontend

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 // src/App.tsx
 import ApiErrorBoundary from './components/common/ApiErrorBoundary';
-import ResilientApiProvider from './context/ResilientApiContext';
+import ResilientApiProvider from './contexts/ResilientApiContext';
 import AppRoutes from './components/AppRoutes';
 import { Toaster } from 'sonner'; // Import Toaster
 import './styles/fonts.css';

--- a/frontend/src/components/APIConfigurationPanel.tsx
+++ b/frontend/src/components/APIConfigurationPanel.tsx
@@ -109,7 +109,25 @@ const SAMPLER_ORDER_OPTIONS = [
 
 const APIConfigurationPanel: React.FC<APIConfigurationPanelProps> = ({ config, onUpdate }) => {
   const [expanded, setExpanded] = useState(true); // Set initial state to true
-  const [settings, setSettings] = useState({
+  const [settings, setSettings] = useState<{
+    max_length: number;
+    max_context_length: number;
+    temperature: number;
+    top_p: number;
+    top_k: number;
+    top_a: number;
+    typical: number;
+    tfs: number;
+    min_p: number;
+    rep_pen: number;
+    rep_pen_range: number;
+    rep_pen_slope: number;
+    sampler_order: number[];
+    dynatemp_enabled: boolean;
+    dynatemp_min: number;
+    dynatemp_max: number;
+    dynatemp_exponent: number;
+  }>({
     max_length: config.generation_settings?.max_length ?? 220,
     max_context_length: config.generation_settings?.max_context_length ?? 6144,
     temperature: config.generation_settings?.temperature ?? 1.05,

--- a/frontend/src/contexts/ResilientApiContext.tsx
+++ b/frontend/src/contexts/ResilientApiContext.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, useContext, ReactNode } from 'react';
+
+interface ResilientApiContextType {
+  retryAllConnections: () => Promise<void>;
+}
+
+const ResilientApiContext = createContext<ResilientApiContextType | undefined>(undefined);
+
+export const useResilientApi = (): ResilientApiContextType => {
+  const context = useContext(ResilientApiContext);
+  if (!context) {
+    throw new Error('useResilientApi must be used within a ResilientApiProvider');
+  }
+  return context;
+};
+
+interface ResilientApiProviderProps {
+  children: ReactNode;
+  retryCount?: number;
+  retryDelay?: number;
+}
+
+const ResilientApiProvider: React.FC<ResilientApiProviderProps> = ({
+  children,
+  retryCount = 5,
+  retryDelay = 2000
+}) => {
+  // Placeholder function for retrying all connections
+  const retryAllConnections = async () => {
+    console.log(`Retry all connections (retryCount: ${retryCount}, retryDelay: ${retryDelay}ms)`);
+    // This is a stub - actual retry logic can be implemented here if needed
+    return Promise.resolve();
+  };
+
+  return (
+    <ResilientApiContext.Provider value={{ retryAllConnections }}>
+      {children}
+    </ResilientApiContext.Provider>
+  );
+};
+
+export default ResilientApiProvider;

--- a/frontend/src/contexts/SettingsContext.tsx
+++ b/frontend/src/contexts/SettingsContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from "react";
 import { Settings, DEFAULT_SETTINGS } from "../types/settings";
-import { useResilientApi } from "../context/ResilientApiContext"; // Keep for retryAllConnections
+import { useResilientApi } from "./ResilientApiContext"; // Keep for retryAllConnections
 import { ContentFilterClient } from "../services/contentFilterClient";
 // Removed unused import: WordSwapRule
 

--- a/frontend/src/hooks/usePrompts.ts
+++ b/frontend/src/hooks/usePrompts.ts
@@ -244,7 +244,7 @@ export const usePrompts = () => {
       // Import modified standard prompts
       if (parsedData.prompts) {
         Object.entries(parsedData.prompts).forEach(([key, value]) => {
-          updatePrompt(key, value);
+          updatePrompt(key, value as string);
         });
       }
 

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -337,18 +337,19 @@ export const listCharacterChats = async (characterData: CharacterData): Promise<
  */
 export const generateResponse = async (prompt: string, config: APIConfig) => {
   // Build the request payload
-  const payload = {
+  const payload: any = {
     prompt,
-    ...(config.generation_settings?.dynatemp_enabled && {
-      dynatemp_config: {
-        dynatemp_range: [
-          config.generation_settings.dynatemp_min, 
-          config.generation_settings.dynatemp_max
-        ],
-        dynatemp_exponent: config.generation_settings.dynatemp_exponent
-      }
-    }),
   };
+
+  if (config.generation_settings?.dynatemp_enabled) {
+    payload.dynatemp_config = {
+      dynatemp_range: [
+        config.generation_settings.dynatemp_min,
+        config.generation_settings.dynatemp_max
+      ],
+      dynatemp_exponent: config.generation_settings.dynatemp_exponent
+    };
+  }
 
   try {
     const response = await fetch('/api/generate-response', {

--- a/frontend/src/services/chat/chatTypes.ts
+++ b/frontend/src/services/chat/chatTypes.ts
@@ -216,7 +216,7 @@ export const ChatSessionSchema = z.object({
   userId: z.string().optional(),
   created_at: z.number().int().positive(),
   updated_at: z.number().int().positive(),
-  metadata: z.record(z.any()).optional()
+  metadata: z.record(z.string(), z.any()).optional()
 });
 
 /**
@@ -239,7 +239,7 @@ export const validateMessage = (data: unknown): { success: true; data: Message }
     return { success: true, data: result as Message };
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return { success: false, error: error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join('; ') };
+      return { success: false, error: error.issues.map(e => `${e.path.join('.')}: ${e.message}`).join('; ') };
     }
     return { success: false, error: 'Unknown validation error' };
   }
@@ -254,7 +254,7 @@ export const validateUserProfile = (data: unknown): { success: true; data: UserP
     return { success: true, data: result as UserProfile };
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return { success: false, error: error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join('; ') };
+      return { success: false, error: error.issues.map(e => `${e.path.join('.')}: ${e.message}`).join('; ') };
     }
     return { success: false, error: 'Unknown validation error' };
   }
@@ -269,7 +269,7 @@ export const validateSaveChatParams = (data: unknown): { success: true; data: Sa
     return { success: true, data: result };
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return { success: false, error: error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join('; ') };
+      return { success: false, error: error.issues.map(e => `${e.path.join('.')}: ${e.message}`).join('; ') };
     }
     return { success: false, error: 'Unknown validation error' };
   }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -184,7 +184,7 @@ export const APIConfigSchema = z.object({
   apiKey: z.string().optional(),
   model: z.string().optional(),
   templateId: z.string().optional(),
-  generation_settings: z.record(z.any()).optional(),
+  generation_settings: z.record(z.string(), z.any()).optional(),
   enabled: z.boolean().default(false),
   lastConnectionStatus: z.object({
     connected: z.boolean(),

--- a/frontend/src/types/promptSchemas.ts
+++ b/frontend/src/types/promptSchemas.ts
@@ -25,7 +25,7 @@ export const newPromptSchema = z.object({
  * Schema for validating prompt exports/imports
  */
 export const PromptExportSchema = z.object({
-  prompts: z.record(z.string()),
+  prompts: z.record(z.string(), z.string()),
   custom: z.array(z.object({
     key: promptKeySchema,
     template: promptTemplateSchema


### PR DESCRIPTION
Fixed multiple TypeScript compilation errors to enable successful build:

1. **Zod API Updates**: Updated all z.record() calls to use the new Zod v3 API that requires explicit key/value schemas (z.record(z.string(), z.any()))
   - Fixed in: api.ts, chatTypes.ts, promptSchemas.ts

2. **ZodError Properties**: Changed error.errors to error.issues in all validation functions to match Zod v3 API
   - Fixed in: chatTypes.ts (3 validation functions)

3. **Type Inference**: Added explicit type annotations to useState in APIConfigurationPanel to prevent TypeScript from inferring {} type
   - Fixed in: APIConfigurationPanel.tsx

4. **Type Assertions**: Added type assertion for unknown values in usePrompts
   - Fixed in: usePrompts.ts (line 247)

5. **Spread Operator**: Refactored conditional spread in apiService to avoid spread type errors
   - Fixed in: apiService.ts

6. **Missing Context**: Created ResilientApiContext stub provider and fixed import paths from ./context/ to ./contexts/
   - Added: ResilientApiContext.tsx
   - Fixed imports in: App.tsx, SettingsContext.tsx

All frontend TypeScript errors are now resolved and build completes successfully.