### PR TITLE
Display alternative greetings in ChatView API payload

### DIFF
--- a/frontend/src/handlers/promptHandler.ts
+++ b/frontend/src/handlers/promptHandler.ts
@@ -465,12 +465,12 @@ Do not editorialize or add interpretation. Just the facts of what happened.`;
           mes_example: characterCard.data.mes_example,
           system_prompt: characterCard.data.system_prompt,
           post_history_instructions: characterCard.data.post_history_instructions,
-          alternate_greetings: characterCard.data.alternate_greetings,
           character_uuid: characterCard.data.character_uuid,
           tags: characterCard.data.tags,
           creator: characterCard.data.creator,
           character_version: characterCard.data.character_version,
           // Explicitly exclude character_book - lore matching should happen on backend
+          // Explicitly exclude alternate_greetings - only selected greeting is sent in chat_history
         }
       } : null;
 


### PR DESCRIPTION
Alternate greetings are not used by backend during generation - only the selected greeting matters (sent as first message in chat_history). This reduces payload size and prevents confusion in API Payload/RAW DATA view.