### PR TITLE
Fix room properties panel in World Card Build

### DIFF
--- a/frontend/src/components/world/GridCanvas.tsx
+++ b/frontend/src/components/world/GridCanvas.tsx
@@ -14,6 +14,7 @@ interface GridCanvasProps {
   onRoomCreate: (position: { x: number; y: number }) => void;
   onRoomDelete: (roomId: string) => void;
   onRoomMove: (roomId: string, newPosition: { x: number; y: number }) => void;
+  onCellClick?: (position: { x: number; y: number }, event: React.MouseEvent) => void;
 }
 
 export function GridCanvas({
@@ -25,6 +26,7 @@ export function GridCanvas({
   onRoomCreate,
   onRoomDelete,
   onRoomMove,
+  onCellClick,
 }: GridCanvasProps) {
   const [zoom, setZoom] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
@@ -40,14 +42,18 @@ export function GridCanvas({
 
     const room = rooms.find(r => r.position.x === x && r.position.y === y);
 
-    // Unified 'edit' tool: select existing rooms OR create new ones on empty cells
+    // Unified 'edit' tool: use onCellClick if provided to show menu, otherwise select directly
     if (activeTool === 'edit') {
-      if (room) {
-        // Select existing room
-        onRoomSelect(room);
+      if (onCellClick) {
+        // Let parent handle the click (will show CellActionMenu)
+        onCellClick({ x, y }, e);
       } else {
-        // Create new room on empty cell
-        onRoomCreate({ x, y });
+        // Fallback: direct selection (legacy behavior)
+        if (room) {
+          onRoomSelect(room);
+        } else {
+          onRoomCreate({ x, y });
+        }
       }
     } else if (activeTool === 'move') {
       // Do nothing on click in move mode, just allow dragging

--- a/frontend/src/components/world/NPCPickerModal.tsx
+++ b/frontend/src/components/world/NPCPickerModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { X, Search, Check } from 'lucide-react';
+import { RoomNPC } from '../../types/room';
 
 interface Character {
   id: string;
@@ -10,19 +11,21 @@ interface Character {
 
 interface NPCPickerModalProps {
   availableCharacters: Character[];
-  selectedNPCs: string[];
-  onConfirm: (npcIds: string[]) => void;
+  selectedNPCs: RoomNPC[]; // Full RoomNPC objects
+  onConfirm: (npcs: RoomNPC[]) => void;
   onClose: () => void;
 }
 
-export function NPCPickerModal({ 
-  availableCharacters, 
-  selectedNPCs, 
-  onConfirm, 
-  onClose 
+export function NPCPickerModal({
+  availableCharacters,
+  selectedNPCs,
+  onConfirm,
+  onClose
 }: NPCPickerModalProps) {
   const [searchQuery, setSearchQuery] = useState('');
-  const [tempSelected, setTempSelected] = useState<string[]>(selectedNPCs);
+  // Extract UUIDs for selection UI
+  const selectedUuids = selectedNPCs.map(npc => npc.character_uuid);
+  const [tempSelected, setTempSelected] = useState<string[]>(selectedUuids);
 
   const filteredCharacters = availableCharacters.filter(char =>
     char.name.toLowerCase().includes(searchQuery.toLowerCase())
@@ -37,7 +40,13 @@ export function NPCPickerModal({
   };
 
   const handleConfirm = () => {
-    onConfirm(tempSelected);
+    // Convert selected UUIDs to RoomNPC objects
+    // Preserve existing RoomNPC data if already selected, create new objects for new selections
+    const npcs: RoomNPC[] = tempSelected.map(uuid => {
+      const existing = selectedNPCs.find(npc => npc.character_uuid === uuid);
+      return existing || { character_uuid: uuid }; // Keep role/hostile if already set
+    });
+    onConfirm(npcs);
   };
 
   return (

--- a/frontend/src/components/world/RoomPropertiesPanel.tsx
+++ b/frontend/src/components/world/RoomPropertiesPanel.tsx
@@ -99,15 +99,15 @@ export function RoomPropertiesPanel({ room, worldId, availableCharacters, onUpda
     }
   };
 
-  const getNpcName = (id: string) => {
-    const char = availableCharacters.find((c: any) => c.id === id);
-    return char ? char.name : id;
+  const getNpcName = (character_uuid: string) => {
+    const char = availableCharacters.find((c: any) => c.id === character_uuid);
+    return char ? char.name : character_uuid;
   };
-  const handleRemoveNPC = (npcId: string) => {
+  const handleRemoveNPC = (character_uuid: string) => {
     if (!room) return;
     onUpdate({
       ...room,
-      npcs: room.npcs.filter(id => id !== npcId),
+      npcs: room.npcs.filter(npc => npc.character_uuid !== character_uuid),
     });
   };
 
@@ -280,16 +280,18 @@ export function RoomPropertiesPanel({ room, worldId, availableCharacters, onUpda
                   </div>
                 ) : (
                   <div className="space-y-2">
-                    {room.npcs.map((npcId) => (
+                    {room.npcs.map((npc) => (
                       <div
-                        key={npcId}
+                        key={npc.character_uuid}
                         className="bg-[#1a1a1a] border border-[#2a2a2a] rounded-lg px-3 py-2 flex items-center justify-between"
                       >
                         <div className="flex items-center gap-2">
                           <Users size={14} className="text-gray-500" />
-                          <span className="text-sm text-white">{getNpcName(npcId)}</span>
+                          <span className="text-sm text-white">{getNpcName(npc.character_uuid)}</span>
+                          {npc.hostile && <span className="text-xs text-red-400 ml-1">(Hostile)</span>}
+                          {npc.role && <span className="text-xs text-gray-500 ml-1">• {npc.role}</span>}
                         </div>
-                        <button className="text-gray-500 hover:text-red-400 transition-colors" onClick={() => handleRemoveNPC(npcId)}>
+                        <button className="text-gray-500 hover:text-red-400 transition-colors" onClick={() => handleRemoveNPC(npc.character_uuid)}>
                           <X size={14} />
                         </button>
                       </div>

--- a/frontend/src/types/room.ts
+++ b/frontend/src/types/room.ts
@@ -17,7 +17,7 @@ export interface RoomNPC {
  */
 export interface RoomData {
   uuid: string; // Room UUID
-  npcs: RoomNPC[]; // NPCs assigned to this room
+  suggestedNpcs: RoomNPC[]; // Suggested NPCs for this room template (copied to world instances)
   // Future fields can be added here:
   // connections?: RoomConnection[]; // Links to other rooms
   // items?: string[]; // Item UUIDs in the room
@@ -99,5 +99,5 @@ export interface UpdateRoomRequest {
   };
   tags?: string[];
   image?: File | null;
-  npcs?: RoomNPC[];
+  suggestedNpcs?: RoomNPC[]; // Suggested NPCs for this room template
 }

--- a/frontend/src/types/worldCard.ts
+++ b/frontend/src/types/worldCard.ts
@@ -3,13 +3,18 @@
 // World cards are character cards with card_type="world" and world-specific extensions
 
 import { WorldState, GridSize, Position } from './worldV2';
+import { RoomNPC } from './room';
 
 /**
  * Room placement in world grid
+ * Stores both the room template reference AND instance-specific data
  */
 export interface WorldRoomPlacement {
-  room_uuid: string; // References a room card UUID
+  room_uuid: string; // References a room card UUID (the template)
   grid_position: Position; // Where this room appears on the world grid
+  instance_npcs?: RoomNPC[]; // Full NPC assignment objects (role, hostile, etc.) - overrides room card's suggestedNpcs
+  instance_image_path?: string; // Custom image for this instance - overrides room card's default image
+  instance_state?: Record<string, any>; // Future: loot taken, doors opened, enemy HP, etc.
 }
 
 /**

--- a/frontend/src/types/worldGrid.ts
+++ b/frontend/src/types/worldGrid.ts
@@ -2,6 +2,8 @@
 // View layer types for grid-based world UI components
 // Used by WorldEditor, WorldPlayView, MapModal, etc.
 
+import { RoomNPC } from './room';
+
 /**
  * Grid-compatible room format for UI rendering.
  * This is the view layer representation of a room on the grid.
@@ -11,7 +13,7 @@ export interface GridRoom {
     name: string;
     description: string;
     introduction_text: string;
-    npcs: string[];  // character UUIDs
+    npcs: RoomNPC[];  // Full NPC assignment objects (includes character_uuid, role, hostile, etc.)
     events: any[];
     connections: Record<string, string | null>;  // { north: 'room-id', south: null, ... }
     position: { x: number; y: number };

--- a/frontend/src/views/WorldEditor.tsx
+++ b/frontend/src/views/WorldEditor.tsx
@@ -474,6 +474,7 @@ export function WorldEditor({ worldId: propWorldId, onBack }: WorldEditorProps) 
             onRoomCreate={handleRoomCreate}
             onRoomDelete={handleRoomDelete}
             onRoomMove={handleRoomMove}
+            onCellClick={handleCellClick}
           />
         </div>
 

--- a/frontend/src/views/WorldEditor.tsx
+++ b/frontend/src/views/WorldEditor.tsx
@@ -86,7 +86,8 @@ export function WorldEditor({ worldId: propWorldId, onBack }: WorldEditorProps) 
             const roomCard = await roomApi.getRoom(placement.room_uuid);
 
             // Convert RoomCard to GridRoom format using adapter
-            const gridRoom = roomCardToGridRoom(roomCard, placement.grid_position);
+            // Pass placement data so instance NPCs/images override room card defaults
+            const gridRoom = roomCardToGridRoom(roomCard, placement.grid_position, placement);
             loadedRooms.push(gridRoom);
           } catch (err) {
             console.warn(`Failed to load room ${placement.room_uuid}:`, err);
@@ -219,16 +220,9 @@ export function WorldEditor({ worldId: propWorldId, onBack }: WorldEditorProps) 
 
     // Load full room card to get all details
     roomApi.getRoom(roomSummary.uuid).then(roomCard => {
-      const newRoom: GridRoom = {
-        id: roomCard.data.character_uuid || roomSummary.uuid,
-        name: roomCard.data.name,
-        description: roomCard.data.description,
-        introduction_text: roomCard.data.first_mes || '',
-        npcs: roomCard.data.extensions.room_data.npcs.map(npc => npc.character_uuid),
-        events: [],
-        connections: { north: null, south: null, east: null, west: null },
-        position: selectedCell,
-      };
+      // Use adapter to create GridRoom with deep-copied suggestedNpcs
+      // No placement data yet since this is a fresh import
+      const newRoom = roomCardToGridRoom(roomCard, selectedCell);
 
       setRooms(prev => [...prev, newRoom]);
       setIsDirty(true);
@@ -309,9 +303,9 @@ export function WorldEditor({ worldId: propWorldId, onBack }: WorldEditorProps) 
     setIsDirty(true);
   }, [rooms]);
 
-  const handleNPCsConfirm = useCallback((npcIds: string[]) => {
+  const handleNPCsConfirm = useCallback((npcs: import('../types/room').RoomNPC[]) => {
     if (selectedRoom) {
-      const updatedRoom = { ...selectedRoom, npcs: npcIds };
+      const updatedRoom = { ...selectedRoom, npcs };
       handleRoomUpdate(updatedRoom);
     }
     setShowNPCPicker(false);
@@ -322,9 +316,13 @@ export function WorldEditor({ worldId: propWorldId, onBack }: WorldEditorProps) 
 
     try {
       // Convert GridRoom[] to WorldRoomPlacement[]
+      // CRITICAL: Persist instance data (NPCs, images) to world card
       const roomPlacements: WorldRoomPlacement[] = rooms.map(room => ({
         room_uuid: room.id,
         grid_position: room.position,
+        instance_npcs: room.npcs.length > 0 ? room.npcs : undefined, // Full RoomNPC[] objects
+        instance_image_path: room.image_path || undefined, // Custom image override
+        // instance_state: undefined, // Future: loot, doors, enemy HP, etc.
       }));
 
       // Calculate required grid size based on room positions

--- a/frontend/src/views/WorldEditor.tsx
+++ b/frontend/src/views/WorldEditor.tsx
@@ -486,7 +486,7 @@ export function WorldEditor({ worldId: propWorldId, onBack }: WorldEditorProps) 
           onUpdate={handleRoomUpdate}
           onClose={() => setSelectedRoom(null)}
           onOpenNPCPicker={() => setShowNPCPicker(true)}
-          isVisible={!!selectedRoom && activeTool === 'edit'}
+          isVisible={!!selectedRoom}
         />
       </div>
 


### PR DESCRIPTION
🐛 Fixed Issues:
1. Room Properties Panel Not Opening ✅

Click behavior now consistent for all cells
Menu shows "Edit Room" option for occupied cells
Properties panel opens when clicking "Edit Room"
2. Menu Appearing at (0,0) ✅

Real mouse event now passed through instead of mock event
Menu appears at actual click position
3. Properties Panel Disappearing When Switching Tools ✅

Panel now stays visible until explicitly dismissed
Can switch between tools while keeping room selected
4. CRITICAL: NPC Assignments Being Lost on Save ✅

Extended WorldRoomPlacement to store instance_npcs, instance_image_path, and instance_state
Changed GridRoom.npcs from string[] to RoomNPC[] (full objects)
Renamed RoomData.npcs → suggestedNpcs for clarity
Updated save logic to persist instance data
Updated load logic to use instance data with fallback to suggested NPCs
Updated all UI components to work with RoomNPC[] objects
📐 Architecture Implemented (Option A):
Room Cards (Templates):

Store suggestedNpcs as defaults
Provide starting point when importing
World Cards (Instances):

Store instance_npcs per room placement
Source of truth at runtime
Deep copy happens on import
💡 Benefits:
Same tavern, different NPCs - Room templates can be reused across campaigns with different NPC assignments
Rich NPC data - Full RoomNPC[] objects include role, hostile flag, ready for combat system
Future expansion - instance_state ready for loot, doors, enemy HP, etc.
Properties panel shows context - Displays "(Hostile)" and role badges next to NPC names
⚠️ Backend Requirements:
The backend needs to accept the new WorldRoomPlacement fields:

instance_npcs?: RoomNPC[]
instance_image_path?: string
instance_state?: Record<string, any>
Old worlds without instance_npcs will gracefully fall back to room card's suggestedNpcs.

All changes committed and pushed to claude/fix-room-properties-panel-c4K1W 🚀