### PR TITLE
Fix Workshop panel positioning above canvas

### DIFF
--- a/frontend/src/components/ComparisonPanel.tsx
+++ b/frontend/src/components/ComparisonPanel.tsx
@@ -32,7 +32,7 @@ const ComparisonPanel: React.FC<ComparisonPanelProps> = ({ settingsChangeCount }
   };
 
   return (
-    <div className="h-full flex flex-col border-l border-stone-800 bg-stone-900">
+    <div className="h-full flex flex-col bg-stone-900 overflow-hidden">
       {/* Header */}
       <div className="p-4 flex justify-between items-center border-b border-stone-800">
         <div className="flex items-center">

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -359,7 +359,7 @@ const Layout: React.FC = () => {
       {/* Main Content Area - added pb-8 to account for bottom banner */}
       <div className={`flex flex-1 ${(isCompareMode || isWorkshopMode) ? 'min-w-0' : 'min-w-[600px]'} bg-stone-900`}>
         {/* Main content column */}
-        <div className={`flex flex-col ${(isCompareMode || isWorkshopMode) ? 'w-1/2' : 'flex-1'} mb-8`}>
+        <div className={`flex flex-col ${(isCompareMode || isWorkshopMode) ? 'w-1/2' : 'flex-1'} mb-8 relative z-0`}>
           {error && (
             <div className="px-8 py-4 bg-red-900/50 text-red-200">{error}</div>
           )}
@@ -374,7 +374,7 @@ const Layout: React.FC = () => {
 
         {/* Panel slot - supports both comparison and workshop panels */}
         {(isCompareMode || isWorkshopMode) && (
-          <div className="w-1/2 border-l border-stone-800">
+          <div className="w-1/2 border-l border-stone-800 relative z-20">
             {isCompareMode && <ComparisonPanel settingsChangeCount={settingsChangeCount} />}
             {isWorkshopMode && (
               <ChatProvider>

--- a/frontend/src/components/WorkshopPanel.tsx
+++ b/frontend/src/components/WorkshopPanel.tsx
@@ -79,7 +79,7 @@ const WorkshopPanel: React.FC<WorkshopPanelProps> = ({ onClose }) => {
   };
 
   return (
-    <div className="h-full flex flex-col bg-stone-900 border-l border-stone-800">
+    <div className="h-full flex flex-col bg-stone-900 overflow-hidden">
       {/* Header */}
       <div className="p-4 flex justify-between items-center border-b border-stone-800">
         <div>

--- a/frontend/src/components/character/CharacterInfoView.tsx
+++ b/frontend/src/components/character/CharacterInfoView.tsx
@@ -486,7 +486,7 @@ const CharacterInfoView: React.FC<CharacterInfoViewProps> = ({ isSecondary = fal
 
               {/* Dropdown Menu */}
               {showOverflowMenu && (
-                <div className="absolute right-0 mt-2 w-56 bg-stone-800 border border-stone-700 rounded-lg shadow-lg z-50 overflow-hidden">
+                <div className="absolute right-0 mt-2 w-56 bg-stone-800 border border-stone-700 rounded-lg shadow-lg z-10 overflow-hidden">
                   <button
                     onClick={handleDuplicate}
                     className="w-full flex items-center gap-3 px-4 py-3 text-left text-white hover:bg-stone-700 transition-colors"


### PR DESCRIPTION
…sues

This commit addresses critical UI positioning problems where the Workshop and Comparison panels were appearing with incorrect stacking order and the Edit button dropdown was overlaying the panels.

Changes:
- Reduced Edit dropdown z-index from z-50 to z-10 to prevent overlay on panels
- Added z-20 to panel container to establish proper stacking above main content
- Added z-0 to main content column to establish base z-level
- Added overflow-hidden to Workshop and Comparison panels to prevent content escape
- Established clear z-index hierarchy: content (z-0) < dropdown (z-10) < panels (z-20) < nav (z-40) < modals (z-50)

Fixes issues where:
- Edit button dropdown was incorrectly appearing over Workshop/Comparison panels
- Panels were not properly positioned within the viewport
- No clear z-index hierarchy caused unpredictable stacking behavior