### PR TITLE
fix: Simplify layout structure to prevent panel push-up issue

### DIFF
--- a/frontend/src/components/ComparisonPanel.tsx
+++ b/frontend/src/components/ComparisonPanel.tsx
@@ -32,7 +32,7 @@ const ComparisonPanel: React.FC<ComparisonPanelProps> = ({ settingsChangeCount }
   };
 
   return (
-    <div className="flex-1 min-h-0 flex flex-col bg-stone-900 overflow-hidden">
+    <div className="h-full flex flex-col bg-stone-900 overflow-hidden">
       {/* Header */}
       <div className="p-4 flex justify-between items-center border-b border-stone-800">
         <div className="flex items-center">
@@ -72,7 +72,7 @@ const ComparisonPanel: React.FC<ComparisonPanelProps> = ({ settingsChangeCount }
       </div>
 
       {/* Content */}
-      <div className="flex-1 min-h-0 overflow-hidden">
+      <div className="flex-1 overflow-hidden">
         {showGallery ? (
           // Show the character gallery for selection
           <CharacterGallery 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -359,36 +359,33 @@ const Layout: React.FC = () => {
         onImageChange={handleImageChange}
       />
 
-      {/* Main Content Area - uses flex to properly divide space */}
-      <div className={`flex flex-col flex-1 ${(isCompareMode || isWorkshopMode) ? 'min-w-0' : 'min-w-[600px]'} bg-stone-900`}>
-        {/* Content wrapper - flex row for side-by-side layout, takes remaining space after banner offset */}
-        <div className="flex flex-1 min-h-0 pb-8">
-          {/* Main content column */}
-          <div className={`flex flex-col ${(isCompareMode || isWorkshopMode) ? 'w-1/2' : 'flex-1'} min-h-0 overflow-hidden relative z-0`}>
-            {error && (
-              <div className="px-8 py-4 bg-red-900/50 text-red-200">{error}</div>
-            )}
-            {isLoading && (
-              <div className="px-8 py-4 bg-blue-900/50 text-blue-200">
-                Loading character data...
-              </div>
-            )}
-            {/* Render the matched nested route component here */}
-            <Outlet />
-          </div>
-
-          {/* Panel slot - supports both comparison and workshop panels */}
-          {(isCompareMode || isWorkshopMode) && (
-            <div className="flex flex-col w-1/2 min-h-0 border-l border-stone-800 relative z-20 overflow-hidden">
-              {isCompareMode && <ComparisonPanel settingsChangeCount={settingsChangeCount} />}
-              {isWorkshopMode && (
-                <ChatProvider disableAutoLoad={true}>
-                  <WorkshopPanel onClose={() => setWorkshopMode(false)} />
-                </ChatProvider>
-              )}
+      {/* Main Content Area - single flex container for side-by-side layout */}
+      <div className={`flex flex-1 ${(isCompareMode || isWorkshopMode) ? 'min-w-0' : 'min-w-[600px]'} pb-8 bg-stone-900 overflow-hidden`}>
+        {/* Main content column */}
+        <div className={`flex flex-col ${(isCompareMode || isWorkshopMode) ? 'w-1/2' : 'flex-1'} h-full overflow-hidden relative z-0`}>
+          {error && (
+            <div className="flex-none px-8 py-4 bg-red-900/50 text-red-200">{error}</div>
+          )}
+          {isLoading && (
+            <div className="flex-none px-8 py-4 bg-blue-900/50 text-blue-200">
+              Loading character data...
             </div>
           )}
+          {/* Render the matched nested route component here */}
+          <Outlet />
         </div>
+
+        {/* Panel slot - supports both comparison and workshop panels */}
+        {(isCompareMode || isWorkshopMode) && (
+          <div className="flex flex-col w-1/2 h-full border-l border-stone-800 relative z-20 overflow-hidden">
+            {isCompareMode && <ComparisonPanel settingsChangeCount={settingsChangeCount} />}
+            {isWorkshopMode && (
+              <ChatProvider disableAutoLoad={true}>
+                <WorkshopPanel onClose={() => setWorkshopMode(false)} />
+              </ChatProvider>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Dialogs */}

--- a/frontend/src/components/WorkshopPanel.tsx
+++ b/frontend/src/components/WorkshopPanel.tsx
@@ -78,7 +78,7 @@ const WorkshopPanel: React.FC<WorkshopPanelProps> = ({ onClose }) => {
   };
 
   return (
-    <div className="flex-1 min-h-0 flex flex-col bg-stone-900 overflow-hidden">
+    <div className="h-full flex flex-col bg-stone-900 overflow-hidden">
       {/* Header */}
       <div className="p-4 flex justify-between items-center border-b border-stone-800">
         <div>
@@ -97,7 +97,7 @@ const WorkshopPanel: React.FC<WorkshopPanelProps> = ({ onClose }) => {
       </div>
 
       {/* Messages Area */}
-      <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
         {/* Error Display */}
         {error && (
           <div className="p-3 bg-red-900/50 text-red-200 rounded-lg">

--- a/frontend/src/components/character/CharacterInfoView.tsx
+++ b/frontend/src/components/character/CharacterInfoView.tsx
@@ -525,7 +525,7 @@ const CharacterInfoView: React.FC<CharacterInfoViewProps> = ({ isSecondary = fal
           )}
         </div>
       </div>
-      <div className="flex-1 min-h-0 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto">
         <div className="px-8 pb-8">
           {/* Show unsaved changes notification */}
           {hasUnsavedChanges && (


### PR DESCRIPTION
Reverted to simpler single-level flex container with:
- overflow-hidden on parent to establish containment boundary
- h-full on children to explicitly inherit height
- Removed nested wrapper that was complicating height calculations

The key fix is overflow-hidden on the main content area which prevents children from expanding beyond the container bounds.