### PR TITLE
fix: Wrap CharacterInfoView in proper flex container instead of fragment

### DIFF
--- a/frontend/src/components/character/CharacterInfoView.tsx
+++ b/frontend/src/components/character/CharacterInfoView.tsx
@@ -419,8 +419,8 @@ const CharacterInfoView: React.FC<CharacterInfoViewProps> = ({ isSecondary = fal
   }, [showOverflowMenu]);
 
   return (
-    <>
-      <div className="p-8 pb-4 flex flex-col gap-4">
+    <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+      <div className="flex-none p-8 pb-4 flex flex-col gap-4">
         <h2 className="text-lg font-semibold">
           {isSecondary ? "Comparison View" : "Primary Character Info"}
         </h2>
@@ -720,7 +720,7 @@ const CharacterInfoView: React.FC<CharacterInfoViewProps> = ({ isSecondary = fal
         onCancel={() => setIsDeleteConfirmOpen(false)}
         onConfirm={handleDelete}
       />
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
- Replaced fragment with flex container for proper height inheritance
- Added flex-none to header to prevent shrinking
- Added min-h-0 and overflow-hidden for proper containment

The fragment was causing layout issues because its children became direct flex items without proper constraints. A single container gives better control over flex behavior.