### PR TITLE
Add Workshop tab to separate chat activity

### DIFF
--- a/backend/database_migrations.py
+++ b/backend/database_migrations.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 # Current schema version - increment when making schema changes
 # When this changes, the old database will be deleted and rebuilt fresh
-CURRENT_SCHEMA_VERSION = "2.2.0"  # Added session_notes and compression_enabled columns for Context Lens feature
+CURRENT_SCHEMA_VERSION = "2.3.0"  # Added chat_type column for Workshop session separation
 
 
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -178,6 +178,7 @@ class ChatSessionCreateV2(BaseModel):
     title: Optional[str] = None
     export_format_version: Optional[str] = None
     is_archived: Optional[bool] = False
+    chat_type: Optional[str] = 'chat'  # 'chat' or 'workshop'
 
 class ChatSessionUpdateV2(BaseModel):
     """Updated ChatSession update schema for database-first approach."""
@@ -197,6 +198,7 @@ class ChatSessionReadV2(BaseModel):
     title: Optional[str] = None
     export_format_version: Optional[str] = None
     is_archived: bool
+    chat_type: Optional[str] = 'chat'  # 'chat' or 'workshop'
     messages: Optional[List[ChatMessageRead]] = None
 
     class Config:

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel # Pydantic models for World
-from typing import Optional, List
+from typing import Optional, List, Literal
 import datetime as dt # Renamed to avoid conflict with sqlalchemy.DateTime
 class WorldBase(BaseModel):
     name: str
@@ -178,7 +178,7 @@ class ChatSessionCreateV2(BaseModel):
     title: Optional[str] = None
     export_format_version: Optional[str] = None
     is_archived: Optional[bool] = False
-    chat_type: Optional[str] = 'chat'  # 'chat' or 'workshop'
+    chat_type: Optional[Literal['chat', 'workshop']] = 'chat'
 
 class ChatSessionUpdateV2(BaseModel):
     """Updated ChatSession update schema for database-first approach."""
@@ -198,7 +198,7 @@ class ChatSessionReadV2(BaseModel):
     title: Optional[str] = None
     export_format_version: Optional[str] = None
     is_archived: bool
-    chat_type: Optional[str] = 'chat'  # 'chat' or 'workshop'
+    chat_type: Optional[Literal['chat', 'workshop']] = 'chat'
     messages: Optional[List[ChatMessageRead]] = None
 
     class Config:

--- a/backend/sql_models.py
+++ b/backend/sql_models.py
@@ -206,6 +206,9 @@ class ChatSession(Base):
     session_notes = Column(Text, nullable=True, default=None)
     compression_enabled = Column(Integer, default=0, nullable=False)  # SQLite uses INTEGER for boolean
 
+    # Chat type for distinguishing regular chats from workshop sessions
+    chat_type = Column(String, default='chat', nullable=False)  # 'chat' or 'workshop'
+
     # Relationships
     character = relationship("Character") # Add back_populates if Character links to ChatSessions
     user_profile = relationship("UserProfile", back_populates="chat_sessions")

--- a/frontend/src/components/WorkshopPanel.tsx
+++ b/frontend/src/components/WorkshopPanel.tsx
@@ -1,6 +1,6 @@
 // frontend/src/components/WorkshopPanel.tsx
 import React, { useState, useEffect, useRef } from 'react';
-import { X } from 'lucide-react';
+import { X, Plus } from 'lucide-react';
 import { useCharacter } from '../contexts/CharacterContext';
 import { useChat } from '../contexts/ChatContext';
 import { usePrompts } from '../hooks/usePrompts';
@@ -49,15 +49,27 @@ const WorkshopPanel: React.FC<WorkshopPanelProps> = ({ onClose }) => {
     isGenerating,
     generateResponse,
     setCharacterDataOverride,
+    createNewChat,
     error,
     clearError
   } = useChat();
   const { getPrompt, getDefaultPrompt } = usePrompts();
 
   const [isInitialized, setIsInitialized] = useState(false);
-  const [workshopNickname] = useState(() => getRandomNickname()); // Pick nickname once on mount
+  const [workshopNickname, setWorkshopNickname] = useState(() => getRandomNickname());
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
+
+  // Handler for starting a new workshop session
+  const handleNewSession = async () => {
+    if (isGenerating) return;
+
+    // Pick a new random nickname for the new session
+    setWorkshopNickname(getRandomNickname());
+
+    // Create a new chat session (this will clear messages and create fresh session)
+    await createNewChat();
+  };
 
   // Filter messages to hide any first_mes that snuck in before the user's first message
   // This handles the race condition where createNewChat might use stale characterDataOverride
@@ -136,13 +148,23 @@ const WorkshopPanel: React.FC<WorkshopPanelProps> = ({ onClose }) => {
             Collaborate with AI to develop {characterData?.data?.name || 'your character'}
           </p>
         </div>
-        <button
-          onClick={onClose}
-          className="p-1 rounded-full hover:bg-stone-800 transition-colors"
-          title="Close workshop"
-        >
-          <X size={18} />
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleNewSession}
+            disabled={isGenerating}
+            className="p-1.5 rounded-full hover:bg-stone-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            title="New workshop session"
+          >
+            <Plus size={18} />
+          </button>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-full hover:bg-stone-800 transition-colors"
+            title="Close workshop"
+          >
+            <X size={18} />
+          </button>
+        </div>
       </div>
 
       {/* Messages Area */}

--- a/frontend/src/components/chat/ChatSelector.tsx
+++ b/frontend/src/components/chat/ChatSelector.tsx
@@ -817,6 +817,11 @@ const ChatSelector: React.FC<ChatSelectorProps> = ({ onSelect, onClose, currentC
                 ? "No other chats found for this character"
                 : "No previous chats found"}
           </p>
+          {activeTab === 'workshop' && (
+            <p className="text-sm text-stone-500 mt-2">
+              Workshop sessions are created from the Workshop panel
+            </p>
+          )}
           {activeTab === 'chats' && (
             <button
               onClick={handleCreateNewChat}

--- a/frontend/src/components/chat/ChatSelector.tsx
+++ b/frontend/src/components/chat/ChatSelector.tsx
@@ -13,7 +13,10 @@ interface ChatInfo {
   messageCount: number;
   preview?: string;
   filename?: string; // For deletion and reference
+  chatType?: 'chat' | 'workshop'; // Type of chat session
 }
+
+type ChatTabType = 'chats' | 'workshop';
 
 interface ChatSelectorProps {
   onSelect?: (chatId: string) => void;
@@ -45,6 +48,9 @@ const ChatSelector: React.FC<ChatSelectorProps> = ({ onSelect, onClose, currentC
   const [isImporting, setIsImporting] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Tab state for separating Chats from Workshop sessions
+  const [activeTab, setActiveTab] = useState<ChatTabType>('chats');
 
   // Load available chats when character changes
   useEffect(() => {
@@ -135,7 +141,8 @@ const ChatSelector: React.FC<ChatSelectorProps> = ({ onSelect, onClose, currentC
             lastModified: formatDate(lastModified),
             rawLastModified: lastModified,
             messageCount,
-            preview: finalPreview
+            preview: finalPreview,
+            chatType: chat.chat_type || 'chat'
           } as ChatInfo;
         }).filter((chat): chat is ChatInfo => chat !== null);
 
@@ -260,6 +267,10 @@ const ChatSelector: React.FC<ChatSelectorProps> = ({ onSelect, onClose, currentC
   const filteredAndSortedChats = useMemo(() => {
     let filtered = [...availableChats];
 
+    // Apply tab filter (Chats vs Workshop)
+    const tabChatType = activeTab === 'workshop' ? 'workshop' : 'chat';
+    filtered = filtered.filter(chat => (chat.chatType || 'chat') === tabChatType);
+
     // Apply search filter
     if (searchTerm) {
       filtered = filtered.filter(chat =>
@@ -328,7 +339,7 @@ const ChatSelector: React.FC<ChatSelectorProps> = ({ onSelect, onClose, currentC
     });
 
     return filtered;
-  }, [availableChats, searchTerm, sortBy, sortOrder, dateFilter, messageCountFilter]);
+  }, [availableChats, searchTerm, sortBy, sortOrder, dateFilter, messageCountFilter, activeTab]);
 
   // Export functionality - Updated for database-centric approach
   const handleExportChats = async (format: 'json' | 'jsonl' = 'json') => {
@@ -642,13 +653,43 @@ const ChatSelector: React.FC<ChatSelectorProps> = ({ onSelect, onClose, currentC
         </div>
       </div>
 
+      {/* Tab Navigation */}
+      <div className="flex border-b border-stone-700 mb-4">
+        <button
+          onClick={() => setActiveTab('chats')}
+          className={`px-4 py-2 text-sm font-medium transition-colors ${
+            activeTab === 'chats'
+              ? 'text-orange-400 border-b-2 border-orange-400'
+              : 'text-stone-400 hover:text-stone-200'
+          }`}
+        >
+          Chats
+          <span className="ml-2 px-1.5 py-0.5 text-xs rounded-full bg-stone-700">
+            {availableChats.filter(c => (c.chatType || 'chat') === 'chat').length}
+          </span>
+        </button>
+        <button
+          onClick={() => setActiveTab('workshop')}
+          className={`px-4 py-2 text-sm font-medium transition-colors ${
+            activeTab === 'workshop'
+              ? 'text-purple-400 border-b-2 border-purple-400'
+              : 'text-stone-400 hover:text-stone-200'
+          }`}
+        >
+          Workshop
+          <span className="ml-2 px-1.5 py-0.5 text-xs rounded-full bg-stone-700">
+            {availableChats.filter(c => c.chatType === 'workshop').length}
+          </span>
+        </button>
+      </div>
+
       {/* Search Bar */}
-      <div className="mb-4 mt-4">
+      <div className="mb-4">
         <div className="relative">
           <Search size={16} className="absolute left-3 top-1/2 transform -translate-y-1/2 text-stone-400" />
           <input
             type="text"
-            placeholder="Search chats by title or content..."
+            placeholder={`Search ${activeTab === 'workshop' ? 'workshop sessions' : 'chats'} by title or content...`}
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             className="w-full pl-10 pr-4 py-2 bg-stone-800 border border-stone-600 rounded-lg focus:outline-none focus:border-orange-500 text-white placeholder-stone-400"
@@ -765,21 +806,26 @@ const ChatSelector: React.FC<ChatSelectorProps> = ({ onSelect, onClose, currentC
       {loading ? (
         <div className="loading p-8 text-center text-stone-400">
           <div className="inline-block w-8 h-8 border-4 border-stone-600 border-t-orange-500 rounded-full animate-spin mb-4"></div>
-          <p>Loading chats...</p>
+          <p>Loading {activeTab === 'workshop' ? 'workshop sessions' : 'chats'}...</p>
         </div>
-      ) : availableChats.length === 0 ? (
+      ) : filteredAndSortedChats.length === 0 ? (
         <div className="no-chats p-8 text-center text-stone-400">
           <p>
-            {currentChatId ?
-              "No other chats found for this character" :
-              "No previous chats found"}
-          </p>          <button
-            onClick={handleCreateNewChat}
-            className="mt-4 px-4 py-2 bg-orange-700 hover:bg-orange-600 rounded-lg flex items-center gap-2 mx-auto transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            disabled={loading}
-          >
-            <Plus size={16} /> Start New Chat
-          </button>
+            {activeTab === 'workshop'
+              ? "No workshop sessions found for this character"
+              : currentChatId
+                ? "No other chats found for this character"
+                : "No previous chats found"}
+          </p>
+          {activeTab === 'chats' && (
+            <button
+              onClick={handleCreateNewChat}
+              className="mt-4 px-4 py-2 bg-orange-700 hover:bg-orange-600 rounded-lg flex items-center gap-2 mx-auto transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={loading}
+            >
+              <Plus size={16} /> Start New Chat
+            </button>
+          )}
         </div>
       ) : (
         <ul className="chat-list space-y-2 max-h-96 overflow-y-auto pr-1">

--- a/frontend/src/services/chatStorage.ts
+++ b/frontend/src/services/chatStorage.ts
@@ -263,17 +263,18 @@ export class ChatStorage {
 
   /**
    * Creates a new chat for a character
+   * @param character - The character to create the chat for
+   * @param chatType - Optional chat type: 'chat' (default) or 'workshop'
    */
-  static async createNewChat(character: CharacterCard | null): Promise<any> {
+  static async createNewChat(character: CharacterCard | null, chatType: 'chat' | 'workshop' = 'chat'): Promise<any> {
     if (!character) {
       console.error('Cannot create chat: No character provided');
       return { success: false, error: 'No character selected' };
     }
 
     try {
-      console.log('Creating new chat for character:', character.data?.name);
+      console.log('Creating new chat for character:', character.data?.name, 'type:', chatType);
 
-      // Extract character ID
       // Extract character ID
       const characterUuid = this.getCharacterId(character);
       if (!characterUuid || characterUuid === 'unknown-character') {
@@ -282,13 +283,13 @@ export class ChatStorage {
       }
       console.log('Using character_uuid:', characterUuid);
 
-      const payload: { character_uuid: string; user_uuid?: string; title?: string } = {
-        character_uuid: characterUuid
+      const payload: { character_uuid: string; user_uuid?: string; title?: string; chat_type?: string } = {
+        character_uuid: characterUuid,
+        chat_type: chatType
       };
       // Optional fields can be added here if available, e.g.:
       // if (currentUser?.uuid) payload.user_uuid = currentUser.uuid;
       // if (character.data?.name) payload.title = `Chat with ${character.data.name}`;
-
 
       const response = await fetch('/api/reliable-create-chat', {
         method: 'POST',


### PR DESCRIPTION
WorkshopPanel.tsx:
Added Plus icon import from lucide-react
Added createNewChat from useChat context
Created handleNewSession function that:
Picks a new random nickname for the fresh session
Calls createNewChat() to clear messages and start a new session
Added the "+" button next to the close button in the header
Button is disabled while generation is in progress

Changes Made
Backend
sql_models.py - Added chat_type column to ChatSession model (default: 'chat', values: 'chat' or 'workshop')

schemas.py - Added chat_type field to both ChatSessionCreateV2 and ChatSessionReadV2 Pydantic schemas

chat_endpoints.py - Updated:

/create-new-chat and /reliable-create-chat endpoints to accept and store chat_type
/reliable-list-chats endpoint to return chat_type in the response
Frontend
chatStorage.ts - Updated createNewChat() to accept optional chatType parameter ('chat' | 'workshop')

ChatContext.tsx - Added automatic Workshop mode detection:

When characterDataOverride is set (Workshop mode), chats are created with chat_type='workshop'
Updated both createNewChat and saveChat functions
ChatSelector.tsx - Added tab UI:

Two tabs: "Chats" and "Workshop" with badge counts
Chats filtered based on selected tab
Tab-aware empty states and search placeholders
How It Works
When you use the Workshop Panel, the characterDataOverride is set, which signals to the ChatContext that we're in Workshop mode
Any chats created during Workshop mode are automatically tagged as chat_type='workshop'
The ChatSelector modal now shows two tabs to filter between regular chats and workshop sessions
Existing chats default to chat_type='chat' so they'll appear in the Chats tab
Notes
The database column uses a default of 'chat' so existing sessions will continue to work
The frontend build passes successfully
Changes pushed to branch claude/add-workshop-tab-7emE6