### PR TITLE
Add image to room via properties

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -146,6 +146,7 @@ from backend.settings_endpoints import router as settings_router
 from backend.template_endpoints import router as template_router  # Import the new template router
 from backend.lore_endpoints import router as lore_router  # Import the lore router
 from backend.room_endpoints import router as room_router # Import the room_router
+from backend.world_asset_endpoints import router as world_asset_router # Import the world asset router
 from backend.npc_room_assignment_endpoints import router as npc_room_assignment_router # Import the new NPC-Room assignment router
 # from backend.character_inventory_endpoints import router as character_inventory_router # REMOVED - functionality integrated into CharacterService
 # from backend.world_chat_endpoints import router as world_chat_router # Removed, functionality merged into world_router
@@ -465,6 +466,7 @@ app.include_router(template_router)  # Include the new template router
 app.include_router(lore_router)  # Include the lore router
 app.include_router(room_router) # Include the room_router
 app.include_router(npc_room_assignment_router) # Include the new NPC-Room assignment router
+app.include_router(world_asset_router) # Include the world asset router
 # app.include_router(character_inventory_router) # REMOVED
 # app.include_router(world_chat_router) # Removed, functionality merged into world_router
 app.include_router(background_router)

--- a/backend/world_asset_endpoints.py
+++ b/backend/world_asset_endpoints.py
@@ -1,0 +1,133 @@
+# backend/world_asset_endpoints.py
+# API endpoints for world asset management (room images, backgrounds, etc.)
+import traceback
+import uuid
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, UploadFile, File, HTTPException
+from fastapi.responses import FileResponse
+
+from backend.log_manager import LogManager
+from backend.world_asset_handler import WorldAssetHandler
+
+from backend.response_models import (
+    DataResponse,
+    STANDARD_RESPONSES,
+    create_data_response,
+)
+from backend.error_handlers import (
+    NotFoundException,
+    handle_generic_error
+)
+from backend.dependencies import (
+    get_logger_dependency,
+    get_world_asset_handler_dependency
+)
+
+# Create router
+router = APIRouter(
+    prefix="/api/world-assets",
+    tags=["worlds"],
+    responses=STANDARD_RESPONSES
+)
+
+
+@router.post("/{world_uuid}", response_model=DataResponse[dict])
+async def upload_world_asset(
+    world_uuid: str,
+    file: UploadFile = File(...),
+    world_asset_handler: WorldAssetHandler = Depends(get_world_asset_handler_dependency),
+    logger: LogManager = Depends(get_logger_dependency)
+):
+    """
+    Upload an asset (image) for a world.
+    Returns the relative path to use for referencing the asset.
+    """
+    try:
+        # Validate file type
+        content_type = file.content_type.lower() if file.content_type else ""
+        allowed_types = ['image/jpeg', 'image/png', 'image/webp', 'image/gif']
+        if content_type not in allowed_types:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported image format. Allowed: {', '.join(t.split('/')[1] for t in allowed_types)}"
+            )
+
+        # Read file content
+        file_content = await file.read()
+
+        # Generate a unique filename to avoid collisions
+        original_filename = file.filename or "asset.png"
+        extension = Path(original_filename).suffix or ".png"
+        unique_filename = f"{uuid.uuid4()}{extension}"
+
+        # Save the asset
+        relative_path = world_asset_handler.save_asset(world_uuid, file_content, unique_filename)
+
+        logger.log_step(f"Uploaded world asset: {relative_path}")
+
+        return create_data_response({
+            "path": relative_path,
+            "filename": unique_filename
+        })
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.log_error(f"Error uploading world asset: {str(e)}")
+        logger.log_error(traceback.format_exc())
+        raise handle_generic_error(e, "uploading world asset")
+
+
+@router.get("/{world_uuid}/{filename}")
+async def get_world_asset(
+    world_uuid: str,
+    filename: str,
+    world_asset_handler: WorldAssetHandler = Depends(get_world_asset_handler_dependency),
+    logger: LogManager = Depends(get_logger_dependency)
+):
+    """
+    Get a world asset (image) by world UUID and filename.
+    """
+    try:
+        # Construct the relative path
+        relative_path = f"{world_uuid}/{filename}"
+
+        # Get the absolute path
+        asset_path = world_asset_handler.get_asset_path(relative_path)
+
+        if not asset_path:
+            raise NotFoundException(f"Asset not found: {relative_path}")
+
+        return FileResponse(asset_path)
+    except NotFoundException:
+        raise
+    except Exception as e:
+        logger.log_error(f"Error getting world asset {world_uuid}/{filename}: {str(e)}")
+        logger.log_error(traceback.format_exc())
+        raise handle_generic_error(e, f"getting world asset {filename}")
+
+
+@router.delete("/{world_uuid}/{filename}", response_model=DataResponse[dict])
+async def delete_world_asset(
+    world_uuid: str,
+    filename: str,
+    world_asset_handler: WorldAssetHandler = Depends(get_world_asset_handler_dependency),
+    logger: LogManager = Depends(get_logger_dependency)
+):
+    """
+    Delete a specific world asset.
+    """
+    try:
+        relative_path = f"{world_uuid}/{filename}"
+        success = world_asset_handler.delete_asset(relative_path)
+
+        if not success:
+            raise NotFoundException(f"Asset not found or could not be deleted: {relative_path}")
+
+        return create_data_response({"deleted": relative_path})
+    except NotFoundException:
+        raise
+    except Exception as e:
+        logger.log_error(f"Error deleting world asset {world_uuid}/{filename}: {str(e)}")
+        logger.log_error(traceback.format_exc())
+        raise handle_generic_error(e, f"deleting world asset {filename}")


### PR DESCRIPTION
The NPC list also now shows a nicer hostile badge with the level (e.g., "Hostile Lv.15" in red) and properly truncates long names/roles.

After restarting your frontend, you'll see a gear icon next to each NPC's X (remove) button in Room Properties. Click it to configure that NPC's room-specific settings.

[feat: Add world asset API endpoints for room image uploads](https://github.com/JStepUX/CardShark/commit/d73a101cbb5ba331c9b37e67a2b67ac384e5eea1)