### PR TITLE
Remove Connections and fix NPC modal layering

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -371,7 +371,7 @@ const Layout: React.FC = () => {
       {/* Main Content Area - single flex container for side-by-side layout */}
       <div className={`flex flex-1 ${(isCompareMode || isWorkshopMode) ? 'min-w-0' : 'min-w-[600px]'} pb-8 bg-stone-900 overflow-hidden`}>
         {/* Main content column */}
-        <div className={`flex flex-col ${(isCompareMode || isWorkshopMode) ? 'w-1/2' : 'flex-1'} h-full overflow-hidden relative z-0`}>
+        <div className={`flex flex-col ${(isCompareMode || isWorkshopMode) ? 'w-1/2' : 'flex-1'} h-full overflow-hidden`}>
           {error && (
             <div className="flex-none px-8 py-4 bg-red-900/50 text-red-200">{error}</div>
           )}

--- a/frontend/src/components/NPCAssignment.tsx
+++ b/frontend/src/components/NPCAssignment.tsx
@@ -225,13 +225,6 @@ export const NPCAssignment: React.FC<NPCAssignmentProps> = ({ npcs, onChange }) 
 
                   {/* Badges */}
                   <div className="flex items-center gap-2 flex-wrap">
-                    {/* Role badge */}
-                    {npc.role && (
-                      <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-blue-900/30 border border-blue-800/50 rounded text-xs text-blue-300">
-                        {npc.role}
-                      </span>
-                    )}
-
                     {/* Hostile badge */}
                     {npc.hostile && (
                       <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-red-900/30 border border-red-800/50 rounded text-xs text-red-300">
@@ -244,7 +237,7 @@ export const NPCAssignment: React.FC<NPCAssignmentProps> = ({ npcs, onChange }) 
                     )}
 
                     {/* No settings indicator */}
-                    {!npc.role && !npc.hostile && (
+                    {!npc.hostile && (
                       <span className="text-xs text-stone-500 italic">No special settings</span>
                     )}
                   </div>

--- a/frontend/src/components/NPCSettingsModal.tsx
+++ b/frontend/src/components/NPCSettingsModal.tsx
@@ -16,13 +16,11 @@ interface NPCSettingsModalProps {
 }
 
 export function NPCSettingsModal({ isOpen, onClose, npc, npcName, onSave }: NPCSettingsModalProps) {
-    const [role, setRole] = useState(npc.role || '');
     const [hostile, setHostile] = useState(npc.hostile || false);
     const [monsterLevel, setMonsterLevel] = useState(npc.monster_level || 1);
 
     // Reset form when NPC changes
     useEffect(() => {
-        setRole(npc.role || '');
         setHostile(npc.hostile || false);
         setMonsterLevel(npc.monster_level || 1);
     }, [npc]);
@@ -32,7 +30,6 @@ export function NPCSettingsModal({ isOpen, onClose, npc, npcName, onSave }: NPCS
     const handleSave = () => {
         const updatedNpc: RoomNPC = {
             ...npc,
-            role: role.trim() || undefined,
             hostile,
             monster_level: hostile ? monsterLevel : undefined,
         };
@@ -42,7 +39,6 @@ export function NPCSettingsModal({ isOpen, onClose, npc, npcName, onSave }: NPCS
 
     const handleCancel = () => {
         // Reset to original values
-        setRole(npc.role || '');
         setHostile(npc.hostile || false);
         setMonsterLevel(npc.monster_level || 1);
         onClose();
@@ -67,24 +63,6 @@ export function NPCSettingsModal({ isOpen, onClose, npc, npcName, onSave }: NPCS
 
                 {/* Content */}
                 <div className="p-6 space-y-6">
-                    {/* Role */}
-                    <div>
-                        <label className="block text-sm font-medium text-stone-300 mb-2">
-                            Role
-                            <span className="text-stone-500 font-normal ml-2">(optional)</span>
-                        </label>
-                        <input
-                            type="text"
-                            value={role}
-                            onChange={(e) => setRole(e.target.value)}
-                            placeholder="e.g., Innkeeper, Guard, Merchant, Quest Giver"
-                            className="w-full bg-stone-800 border border-stone-700 rounded-lg px-4 py-2.5 text-sm text-white placeholder-stone-500 focus:outline-none focus:border-blue-500 transition-colors"
-                        />
-                        <p className="text-xs text-stone-500 mt-1">
-                            Defines the NPC's function in this room (overrides character description)
-                        </p>
-                    </div>
-
                     {/* Hostile Toggle */}
                     <div className="bg-stone-800 border border-stone-700 rounded-lg p-4">
                         <label className="flex items-start gap-3 cursor-pointer">

--- a/frontend/src/components/world/GridCanvas.tsx
+++ b/frontend/src/components/world/GridCanvas.tsx
@@ -61,9 +61,6 @@ export function GridCanvas({
     } else if (activeTool === 'eraser' && room) {
       onRoomDelete(room.id);
       onRoomSelect(null);
-    } else if (activeTool === 'connection' && room) {
-      // Select room for connection mode
-      onRoomSelect(room);
     }
   };
 

--- a/frontend/src/components/world/RoomPropertiesPanel.tsx
+++ b/frontend/src/components/world/RoomPropertiesPanel.tsx
@@ -215,7 +215,7 @@ export function RoomPropertiesPanel({ room, worldId, availableCharacters, onUpda
                   value={room.description}
                   onChange={(e) => onUpdate({ ...room, description: e.target.value })}
                   className="w-full bg-[#1a1a1a] border border-[#2a2a2a] rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-[#3a3a3a] transition-colors resize-none mb-1"
-                  rows={2}
+                  rows={5}
                   placeholder="Describe this room..."
                 />
               </div>
@@ -240,7 +240,7 @@ export function RoomPropertiesPanel({ room, worldId, availableCharacters, onUpda
                   value={room.introduction_text}
                   onChange={(e) => onUpdate({ ...room, introduction_text: e.target.value })}
                   className="w-full bg-[#1a1a1a] border border-[#2a2a2a] rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-[#3a3a3a] transition-colors resize-none"
-                  rows={2}
+                  rows={5}
                   placeholder="Text shown when entering room..."
                 />
               </div>
@@ -340,25 +340,6 @@ export function RoomPropertiesPanel({ room, worldId, availableCharacters, onUpda
                     ))}
                   </div>
                 )}
-              </div>
-
-              {/* Connections */}
-              <div>
-                <label className="block text-xs text-gray-400 mb-2">Connections</label>
-                <div className="grid grid-cols-2 gap-2">
-                  {(['north', 'south', 'east', 'west'] as const).map((direction) => (
-                    <div
-                      key={direction}
-                      className={`bg-[#1a1a1a] border border-[#2a2a2a] rounded-lg px-3 py-2 text-xs ${room.connections[direction] ? 'text-green-400' : 'text-gray-600'
-                        }`}
-                    >
-                      <div className="capitalize">{direction}</div>
-                      <div className="text-xs opacity-60">
-                        {room.connections[direction] ? 'Connected' : 'None'}
-                      </div>
-                    </div>
-                  ))}
-                </div>
               </div>
 
               {/* Position Info */}

--- a/frontend/src/components/world/RoomPropertiesPanel.tsx
+++ b/frontend/src/components/world/RoomPropertiesPanel.tsx
@@ -318,7 +318,6 @@ export function RoomPropertiesPanel({ room, worldId, availableCharacters, onUpda
                               Hostile {npc.monster_level ? `Lv.${npc.monster_level}` : ''}
                             </span>
                           )}
-                          {npc.role && <span className="text-xs text-gray-500 truncate">• {npc.role}</span>}
                         </div>
                         <div className="flex items-center gap-1 shrink-0">
                           <button

--- a/frontend/src/components/world/ToolPalette.tsx
+++ b/frontend/src/components/world/ToolPalette.tsx
@@ -1,7 +1,7 @@
-import { Edit3, Link2, Trash2, Move, ChevronLeft } from 'lucide-react';
+import { Edit3, Trash2, Move, ChevronLeft } from 'lucide-react';
 
-// Define Tool type - simplified to 4 tools
-type Tool = 'edit' | 'move' | 'connection' | 'eraser';
+// Define Tool type - simplified to 3 tools
+type Tool = 'edit' | 'move' | 'eraser';
 
 interface ToolPaletteProps {
   activeTool: Tool;
@@ -13,7 +13,6 @@ interface ToolPaletteProps {
 const tools: { id: Tool; icon: typeof Edit3; label: string; shortcut: string; description: string }[] = [
   { id: 'edit', icon: Edit3, label: 'Edit', shortcut: 'E', description: 'Select rooms to edit properties' },
   { id: 'move', icon: Move, label: 'Move', shortcut: 'M', description: 'Drag and drop rooms to rearrange' },
-  { id: 'connection', icon: Link2, label: 'Connect', shortcut: 'C', description: 'Link rooms together' },
   { id: 'eraser', icon: Trash2, label: 'Delete', shortcut: 'D', description: 'Remove rooms' },
 ];
 

--- a/frontend/src/views/WorldEditor.tsx
+++ b/frontend/src/views/WorldEditor.tsx
@@ -151,9 +151,6 @@ export function WorldEditor({ worldId: propWorldId, onBack }: WorldEditorProps) 
         case 'm':
           setActiveTool('move');
           break;
-        case 'c':
-          setActiveTool('connection');
-          break;
         case 'd':
           setActiveTool('eraser');
           break;

--- a/frontend/src/views/WorldLauncher.tsx
+++ b/frontend/src/views/WorldLauncher.tsx
@@ -64,7 +64,7 @@ const WorldLauncher: React.FC = () => {
                   mes_example: worldCard.data.mes_example,
                   creator_notes: worldCard.data.creator_notes,
                   tags: worldCard.data.tags,
-                  extensions: worldCard.data.extensions,
+                  extensions: worldCard.data.extensions as unknown as CharacterData['data']['extensions'],
                   character_uuid: uuid,
                   creator: worldCard.data.creator,
                }


### PR DESCRIPTION
- Remove Connect tool from ToolPalette and keyboard shortcut
- Remove Connections section from Room Properties panel
- Fix z-index issue where NPC select and text modals appeared under SideNav
- Increase Description and Introduction textarea rows from 2 to 5
- Fix pre-existing TypeScript type issue in WorldLauncher.tsx