### PR TITLE
Fix chat button loading wrong panel

### DIFF
--- a/frontend/src/utils/worldStateApi.ts
+++ b/frontend/src/utils/worldStateApi.ts
@@ -54,7 +54,8 @@ export async function resolveNpcDisplayData(npcIds: string[]): Promise<DisplayNP
     }
 
     const data = await response.json();
-    const characters = data.data || data || [];
+    // Handle multiple API response formats: { characters: [...] }, { data: [...] }, or direct array
+    const characters = data.characters || data.data || (Array.isArray(data) ? data : []);
 
     const results: DisplayNPC[] = [];
 


### PR DESCRIPTION
The resolveNpcDisplayData function was not correctly handling the /api/characters response format. The API returns { characters: [...] } but the function only checked for data.data || data, missing the data.characters case.

This caused the function to fail silently (caught exception) and return an empty array, resulting in "No one else is here" even when NPCs were properly assigned to the room.

The map modal worked because it directly counts room.npcs.length without needing to resolve character details from the API.