### PR TITLE
Implement room management system for worlds

### DIFF
--- a/backend/models/room_card.py
+++ b/backend/models/room_card.py
@@ -26,6 +26,7 @@ class RoomData(BaseModel):
     """
     uuid: str = Field(..., description="Unique identifier for the room")
     npcs: List[RoomNPC] = Field(default_factory=list, description="NPCs assigned to this room")
+    created_by_world_uuid: Optional[str] = Field(None, description="UUID of the world that auto-generated this room from lore (None if manually created)")
 
     # Future fields for expansion:
     # connections: List[RoomConnection] = Field(default_factory=list)
@@ -84,6 +85,7 @@ class RoomCardSummary(BaseModel):
     description: str = Field(default="", description="Room description")
     image_path: Optional[str] = Field(None, description="Path to room image PNG")
     assigned_worlds: Optional[List[str]] = Field(default_factory=list, description="World UUIDs this room is assigned to")
+    created_by_world_uuid: Optional[str] = Field(None, description="UUID of the world that auto-generated this room (None if manually created)")
     npc_count: Optional[int] = Field(0, description="Number of NPCs in the room")
     created_at: Optional[str] = Field(None, description="ISO8601 creation timestamp")
     updated_at: Optional[str] = Field(None, description="ISO8601 last update timestamp")
@@ -95,6 +97,7 @@ class CreateRoomRequest(BaseModel):
     description: Optional[str] = Field("", description="Room description")
     first_mes: Optional[str] = Field(None, description="Introduction text")
     system_prompt: Optional[str] = Field(None, description="Room atmosphere/system prompt")
+    created_by_world_uuid: Optional[str] = Field(None, description="UUID of the world auto-generating this room (internal use)")
 
     class Config:
         json_schema_extra = {
@@ -121,13 +124,14 @@ class UpdateRoomRequest(BaseModel):
         extra = "forbid"
 
 
-def create_empty_room_card(name: str, room_uuid: Optional[str] = None) -> RoomCard:
+def create_empty_room_card(name: str, room_uuid: Optional[str] = None, created_by_world_uuid: Optional[str] = None) -> RoomCard:
     """
     Helper function to create an empty room card
 
     Args:
         name: Room name
         room_uuid: Optional UUID (generates one if not provided)
+        created_by_world_uuid: Optional UUID of the world auto-generating this room
 
     Returns:
         RoomCard with minimal data
@@ -135,7 +139,7 @@ def create_empty_room_card(name: str, room_uuid: Optional[str] = None) -> RoomCa
     if room_uuid is None:
         room_uuid = str(uuid_module.uuid4())
 
-    room_data = RoomData(uuid=room_uuid, npcs=[])
+    room_data = RoomData(uuid=room_uuid, npcs=[], created_by_world_uuid=created_by_world_uuid)
     extensions = RoomCardExtensions(card_type="room", room_data=room_data)
 
     card_data = RoomCardData(

--- a/backend/models/world_card.py
+++ b/backend/models/world_card.py
@@ -131,6 +131,22 @@ class UpdateWorldRequest(BaseModel):
         extra = "forbid"
 
 
+class RoomDeleteInfo(BaseModel):
+    """Information about a room for delete preview"""
+    uuid: str = Field(..., description="Room UUID")
+    name: str = Field(..., description="Room name")
+    reason: str = Field(..., description="Why this room will/won't be deleted")
+
+
+class WorldDeletePreview(BaseModel):
+    """Preview of what will happen when a world is deleted"""
+    world_uuid: str = Field(..., description="UUID of the world to be deleted")
+    world_name: str = Field(..., description="Name of the world to be deleted")
+    rooms_to_delete: List[RoomDeleteInfo] = Field(default_factory=list, description="Rooms that will be deleted (auto-generated and orphaned)")
+    rooms_to_keep: List[RoomDeleteInfo] = Field(default_factory=list, description="Rooms that will be kept (manually created or used by other worlds)")
+    total_rooms: int = Field(0, description="Total number of rooms in this world")
+
+
 def create_empty_world_card(name: str, world_uuid: Optional[str] = None, grid_size: Optional[GridSize] = None) -> WorldCard:
     """
     Helper function to create an empty world card

--- a/frontend/src/api/roomApi.ts
+++ b/frontend/src/api/roomApi.ts
@@ -174,4 +174,46 @@ export const roomApi = {
   getRoomImageUrl(uuid: string): string {
     return `${BASE_URL}/${uuid}/image`;
   },
+
+  /**
+   * Lists all orphaned rooms (rooms not assigned to any world that were auto-generated).
+   *
+   * @returns Object with orphaned_rooms array and count
+   */
+  async listOrphanedRooms(): Promise<{ orphaned_rooms: RoomCardSummary[]; count: number }> {
+    const response = await fetch(`${BASE_URL}/orphaned/list`);
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ detail: 'Failed to list orphaned rooms' }));
+      throw new Error(error.detail || 'Failed to list orphaned rooms');
+    }
+
+    const data = await response.json();
+    return data.data;
+  },
+
+  /**
+   * Deletes all orphaned rooms (rooms not assigned to any world that were auto-generated).
+   *
+   * @returns Object with deletion results
+   */
+  async cleanupOrphanedRooms(): Promise<{
+    success: boolean;
+    deleted_count: number;
+    failed_count: number;
+    deleted_names: string[];
+    message: string;
+  }> {
+    const response = await fetch(`${BASE_URL}/orphaned/cleanup`, {
+      method: 'DELETE',
+    });
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ detail: 'Failed to cleanup orphaned rooms' }));
+      throw new Error(error.detail || 'Failed to cleanup orphaned rooms');
+    }
+
+    const data = await response.json();
+    return data.data;
+  },
 };

--- a/frontend/src/api/worldApi.ts
+++ b/frontend/src/api/worldApi.ts
@@ -5,7 +5,9 @@ import {
   WorldCard,
   WorldCardSummary,
   CreateWorldRequest,
-  UpdateWorldRequest
+  UpdateWorldRequest,
+  WorldDeletePreview,
+  WorldDeleteResult
 } from '../types/worldCard';
 
 const BASE_URL = '/api/world-cards-v2';
@@ -97,9 +99,25 @@ export const worldApi = {
   },
 
   /**
-   * Delete a world card
+   * Get a preview of what will happen when deleting a world
+   * Shows which rooms will be deleted vs kept
    */
-  async deleteWorld(uuid: string): Promise<void> {
+  async getDeletePreview(uuid: string): Promise<WorldDeletePreview> {
+    const response = await fetch(`${BASE_URL}/${uuid}/delete-preview`);
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ detail: 'Failed to get delete preview' }));
+      throw new Error(error.detail || 'Failed to get delete preview');
+    }
+
+    const data = await response.json();
+    return data.data.preview;
+  },
+
+  /**
+   * Delete a world card (simple - keeps all rooms)
+   */
+  async deleteWorld(uuid: string): Promise<WorldDeleteResult> {
     const response = await fetch(`${BASE_URL}/${uuid}`, {
       method: 'DELETE',
     });
@@ -108,6 +126,26 @@ export const worldApi = {
       const error = await response.json().catch(() => ({ detail: 'Failed to delete world' }));
       throw new Error(error.detail || 'Failed to delete world');
     }
+
+    const data = await response.json();
+    return data.data;
+  },
+
+  /**
+   * Delete a world card with optional cascade deletion of auto-generated rooms
+   */
+  async deleteWorldWithRooms(uuid: string, deleteRooms: boolean = true): Promise<WorldDeleteResult> {
+    const response = await fetch(`${BASE_URL}/${uuid}?delete_rooms=${deleteRooms}`, {
+      method: 'DELETE',
+    });
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ detail: 'Failed to delete world' }));
+      throw new Error(error.detail || 'Failed to delete world');
+    }
+
+    const data = await response.json();
+    return data.data;
   },
 
   /**

--- a/frontend/src/components/common/WorldDeleteConfirmationDialog.tsx
+++ b/frontend/src/components/common/WorldDeleteConfirmationDialog.tsx
@@ -1,0 +1,210 @@
+import React, { useEffect, useState } from 'react';
+import { AlertTriangle, Trash2, DoorOpen } from 'lucide-react';
+import LoadingSpinner from './LoadingSpinner';
+import { Dialog } from './Dialog';
+import { worldApi } from '../../api/worldApi';
+import { WorldDeletePreview } from '../../types/worldCard';
+
+interface WorldDeleteConfirmationDialogProps {
+  isOpen: boolean;
+  worldUuid: string;
+  worldName: string;
+  isDeleting: boolean;
+  onCancel: () => void;
+  onConfirm: (deleteRooms: boolean) => void;
+}
+
+/**
+ * A specialized confirmation dialog for world deletion
+ * Shows a preview of which rooms will be deleted vs kept
+ */
+const WorldDeleteConfirmationDialog: React.FC<WorldDeleteConfirmationDialogProps> = ({
+  isOpen,
+  worldUuid,
+  worldName,
+  isDeleting,
+  onCancel,
+  onConfirm
+}) => {
+  const [preview, setPreview] = useState<WorldDeletePreview | null>(null);
+  const [loadingPreview, setLoadingPreview] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+
+  // Load preview when dialog opens
+  useEffect(() => {
+    if (isOpen && worldUuid) {
+      setLoadingPreview(true);
+      setPreviewError(null);
+
+      worldApi.getDeletePreview(worldUuid)
+        .then(data => {
+          setPreview(data);
+          setLoadingPreview(false);
+        })
+        .catch(err => {
+          setPreviewError(err.message || 'Failed to load preview');
+          setLoadingPreview(false);
+        });
+    } else {
+      // Reset state when dialog closes
+      setPreview(null);
+      setPreviewError(null);
+    }
+  }, [isOpen, worldUuid]);
+
+  const hasRoomsToDelete = preview && preview.rooms_to_delete.length > 0;
+  const hasRoomsToKeep = preview && preview.rooms_to_keep.length > 0;
+
+  const deleteWithRoomsLabel = isDeleting ? (
+    <span className="flex items-center gap-2">
+      <LoadingSpinner size="sm" />
+      Deleting...
+    </span>
+  ) : (
+    `Delete World + ${preview?.rooms_to_delete.length || 0} Room(s)`
+  );
+
+  const deleteWorldOnlyLabel = isDeleting ? (
+    <span className="flex items-center gap-2">
+      <LoadingSpinner size="sm" />
+      Deleting...
+    </span>
+  ) : (
+    'Delete World Only'
+  );
+
+  // Build buttons based on preview
+  const buttons = [];
+
+  buttons.push({
+    label: 'Cancel',
+    onClick: onCancel,
+    variant: 'secondary' as const,
+    disabled: isDeleting,
+  });
+
+  if (hasRoomsToDelete) {
+    // Two options: delete world only, or delete world + rooms
+    buttons.push({
+      label: deleteWorldOnlyLabel,
+      onClick: () => onConfirm(false),
+      variant: 'secondary' as const,
+      disabled: isDeleting || loadingPreview,
+      className: "bg-stone-700 hover:bg-stone-600 text-white",
+    });
+    buttons.push({
+      label: deleteWithRoomsLabel,
+      onClick: () => onConfirm(true),
+      variant: 'primary' as const,
+      disabled: isDeleting || loadingPreview,
+      className: "bg-red-700 hover:bg-red-600 text-white disabled:bg-red-700/50 disabled:text-white/70",
+    });
+  } else {
+    // No rooms to delete, just one delete button
+    buttons.push({
+      label: isDeleting ? (
+        <span className="flex items-center gap-2">
+          <LoadingSpinner size="sm" />
+          Deleting...
+        </span>
+      ) : 'Delete World',
+      onClick: () => onConfirm(false),
+      variant: 'primary' as const,
+      disabled: isDeleting || loadingPreview,
+      className: "bg-red-700 hover:bg-red-600 text-white disabled:bg-red-700/50 disabled:text-white/70",
+    });
+  }
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onCancel}
+      title="Delete World"
+      buttons={buttons}
+      className="max-w-lg"
+    >
+      <div className="flex flex-col gap-4">
+        {/* Header with warning icon */}
+        <div className="flex items-start gap-4">
+          <div className="p-2 bg-red-900/30 rounded-full flex-shrink-0">
+            <AlertTriangle className="text-red-500 h-6 w-6" />
+          </div>
+          <div className="flex-1">
+            <p className="text-stone-300 mb-2">
+              Are you sure you want to delete this world?
+            </p>
+            <div className="p-3 bg-stone-800 rounded mb-4 border border-stone-700 text-stone-300">
+              {worldName}
+            </div>
+          </div>
+        </div>
+
+        {/* Loading state */}
+        {loadingPreview && (
+          <div className="flex items-center justify-center py-4">
+            <LoadingSpinner text="Loading room information..." />
+          </div>
+        )}
+
+        {/* Error state */}
+        {previewError && (
+          <div className="p-3 bg-red-900/30 border border-red-700 rounded text-red-400 text-sm">
+            {previewError}
+          </div>
+        )}
+
+        {/* Preview content */}
+        {preview && !loadingPreview && (
+          <div className="space-y-4">
+            {/* Rooms to delete */}
+            {hasRoomsToDelete && (
+              <div className="bg-red-900/20 border border-red-800/50 rounded-lg p-3">
+                <h4 className="text-red-400 font-medium mb-2 flex items-center gap-2">
+                  <Trash2 size={16} />
+                  {preview.rooms_to_delete.length} room(s) will be deleted:
+                </h4>
+                <ul className="space-y-1 max-h-32 overflow-y-auto">
+                  {preview.rooms_to_delete.map(room => (
+                    <li key={room.uuid} className="flex items-center gap-2 text-sm text-stone-300">
+                      <DoorOpen size={14} className="text-red-400 flex-shrink-0" />
+                      <span className="truncate">{room.name}</span>
+                      <span className="text-stone-500 text-xs">({room.reason})</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {/* Rooms to keep */}
+            {hasRoomsToKeep && (
+              <div className="bg-stone-800/50 border border-stone-700 rounded-lg p-3">
+                <h4 className="text-stone-400 font-medium mb-2 flex items-center gap-2">
+                  <DoorOpen size={16} />
+                  {preview.rooms_to_keep.length} room(s) will be kept:
+                </h4>
+                <ul className="space-y-1 max-h-32 overflow-y-auto">
+                  {preview.rooms_to_keep.map(room => (
+                    <li key={room.uuid} className="flex items-center gap-2 text-sm text-stone-400">
+                      <DoorOpen size={14} className="text-stone-500 flex-shrink-0" />
+                      <span className="truncate">{room.name}</span>
+                      <span className="text-stone-500 text-xs">({room.reason})</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {/* No rooms message */}
+            {!hasRoomsToDelete && !hasRoomsToKeep && (
+              <p className="text-stone-400 text-sm">
+                This world has no rooms.
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </Dialog>
+  );
+};
+
+export default WorldDeleteConfirmationDialog;

--- a/frontend/src/types/room.ts
+++ b/frontend/src/types/room.ts
@@ -19,6 +19,7 @@ export interface RoomNPC {
 export interface RoomData {
   uuid: string; // Room UUID
   npcs: RoomNPC[]; // NPCs assigned to this room (character_uuid, role, hostile, etc.)
+  created_by_world_uuid?: string; // UUID of the world that auto-generated this room (null if manually created)
   // Future fields can be added here:
   // connections?: RoomConnection[]; // Links to other rooms
   // items?: string[]; // Item UUIDs in the room
@@ -70,6 +71,7 @@ export interface RoomCardSummary {
   description: string;
   image_path?: string;
   assigned_worlds?: string[]; // World UUIDs this room is assigned to (computed)
+  created_by_world_uuid?: string; // UUID of the world that auto-generated this room (null if manually created)
   npc_count?: number; // Number of NPCs in the room
   created_at?: string;
   updated_at?: string;

--- a/frontend/src/types/worldCard.ts
+++ b/frontend/src/types/worldCard.ts
@@ -116,3 +116,34 @@ export interface UpdateWorldRequest {
   player_position?: Position;
   image?: File | null;
 }
+
+/**
+ * Information about a room for delete preview
+ */
+export interface RoomDeleteInfo {
+  uuid: string;
+  name: string;
+  reason: string; // Why this room will/won't be deleted
+}
+
+/**
+ * Preview of what will happen when a world is deleted
+ */
+export interface WorldDeletePreview {
+  world_uuid: string;
+  world_name: string;
+  rooms_to_delete: RoomDeleteInfo[]; // Rooms that will be deleted (auto-generated and orphaned)
+  rooms_to_keep: RoomDeleteInfo[]; // Rooms that will be kept (manually created or used elsewhere)
+  total_rooms: number;
+}
+
+/**
+ * Result of deleting a world with rooms
+ */
+export interface WorldDeleteResult {
+  success: boolean;
+  world_deleted: boolean;
+  rooms_deleted: number;
+  rooms_kept: number;
+  message: string;
+}


### PR DESCRIPTION
- Add created_by_world_uuid field to track room origin (auto-generated vs manual)
- Compute assigned_worlds when fetching rooms to show world usage
- Implement smart world deletion with room cascade options:
  - Preview which rooms will be deleted vs kept
  - Option to delete world only or delete with auto-generated rooms
- Add orphan cleanup tool to remove unused auto-generated rooms
- Create WorldDeleteConfirmationDialog for visual room impact preview

This prevents accumulation of duplicate/orphaned rooms when testing worlds.